### PR TITLE
Update learning_curves.rst

### DIFF
--- a/docs/source/examples/learning_curves.rst
+++ b/docs/source/examples/learning_curves.rst
@@ -31,7 +31,7 @@ simple logistic regression. First, let's define such a model:
   from fklearn.training.classification import logistic_classification_learner
 
   input_df = get_data_from_source()
-  model = logistic_classification_learner(fetures: LIST_OF_MODEL_FEATURES
+  model = logistic_classification_learner(features: LIST_OF_MODEL_FEATURES
                                           target: NAME_FOR_TARGET_COL,
                                           prediction_column: NAME_FOR_PREDICTION_COL)
 

--- a/docs/source/examples/learning_curves.rst
+++ b/docs/source/examples/learning_curves.rst
@@ -31,9 +31,9 @@ simple logistic regression. First, let's define such a model:
   from fklearn.training.classification import logistic_classification_learner
 
   input_df = get_data_from_source()
-  model = logistic_classification_learner(features: LIST_OF_MODEL_FEATURES
-                                          target: NAME_FOR_TARGET_COL,
-                                          prediction_column: NAME_FOR_PREDICTION_COL)
+  model = logistic_classification_learner(features=LIST_OF_MODEL_FEATURES
+                                          target=NAME_FOR_TARGET_COL,
+                                          prediction_column=NAME_FOR_PREDICTION_COL)
 
 
 Note that we *did not* pass the data as an input for the function. The reason for this is that Fklearn functions are *curried*,


### PR DESCRIPTION
Just a simple typo on the argument  `feature` of the `logistic_classification_learner`  function

### Instructions
- Follow the instructions in [README.md](../blob/master/README.md)
- Delete everything between parenthesis _(...)_
- Remove the sections that are not relevant

### Status
**READY**
- READY: development over and everything ready for merging

### Todo list
- [X] Documentation

### Background context
As seem on the description the function `logistic_classification_learner` it uses an argument called `features`, but in `Examples/Learning Curves` section of the documentation the argument has a typing error, instead of features it's written fetures.

### Description of the changes proposed in the pull request
Fixed typo existing in the documentation.

### Related PRs
None

### Where should the reviewer start?
Function's declaration: https://github.com/nubank/fklearn/blob/master/src/fklearn/training/classification.py

### Remaining problems or questions
None