### PR TITLE
Typo on learner_doc_string of onehot_categorizer function - issue #75

### DIFF
--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -718,7 +718,7 @@ def onehot_categorizer(df: pd.DataFrame,
     return p, p(df), log
 
 
-quantile_biner.__doc__ += learner_return_docstring("Onehot Categorizer")
+onehot_categorizer.__doc__ += learner_return_docstring("Onehot Categorizer")
 
 
 @curry


### PR DESCRIPTION
### Instructions
Typo correction on onehot_categorizer learner.

### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests passed
- [x] Issue: closes #75 

### Background context
There was a typo on onehot_categorizer learner.

### Description of the changes proposed in the pull request
Remove:
-quantile_biner.__doc__ += learner_return_docstring("Onehot Categorizer")

Add:
+onehot_categorizer.__doc__ += learner_return_docstring("Onehot Categorizer")

### Where should the reviewer start?
 src/fklearn/training/transformation.py
