### PR TITLE
Make `customer_transformer` a pure function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,6 @@ Temporary Items
 
 .pytest_cache/
 .iml
+
+# Vim swap files
+*.swp

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -768,7 +768,8 @@ standard_scaler.__doc__ += learner_return_docstring("Standard Scaler")
 @log_learner_time(learner_name='custom_transformer')
 def custom_transformer(df: pd.DataFrame,
                        columns_to_transform: List[str],
-                       transformation_function: Callable[[pd.DataFrame], pd.DataFrame]) -> LearnerReturnType:
+                       transformation_function: Callable[[pd.DataFrame], pd.DataFrame],
+                       is_vectorized: bool = False) -> LearnerReturnType:
     """
     Applies a custom function to the desired columns.
 
@@ -786,10 +787,11 @@ def custom_transformer(df: pd.DataFrame,
 
     """
 
-    def p(new_data_set: pd.DataFrame) -> pd.DataFrame:
-        new_data_set[columns_to_transform] = new_data_set[columns_to_transform].swifter.apply(transformation_function)
+    def p(df: pd.DataFrame) -> pd.DataFrame:
+        if is_vectorized:
+            return df.assign(**{col: transformation_function(df[col]) for col in columns_to_transform})
 
-        return new_data_set
+        return df.assign(**{col: df[col].swifter.apply(transformation_function) for col in columns_to_transform})
 
     p.__doc__ = learner_pred_fn_docstring("custom_transformer")
 

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 
+import math
 import pandas as pd
-from numpy import nan, round, sqrt
+from numpy import nan, round, sqrt, floor, log as ln
 from numpy.testing import assert_almost_equal
 
 from fklearn.training.transformation import \
@@ -497,17 +498,23 @@ def test_discrete_ecdfer():
 def test_custom_transformer():
     input_df = pd.DataFrame({
         'feat1': [1, 2, 3],
+        'feat2': [math.e, math.e ** 2, math.e ** 3],
+        'feat3': [1.5, 2.5, 3.5],
         'target': [1, 4, 9]
     })
 
     expected = pd.DataFrame({
         'feat1': [1, 2, 3],
+        'feat2': [math.e, math.e ** 2, math.e ** 3],
+        'feat3': [1.5, 2.5, 3.5],
         'target': [1.0, 2.0, 3.0]
     })
 
     expected2 = pd.DataFrame({
         'feat1': [1, 4, 9],
-        'target': [1.0, 2.0, 3.0]
+        'feat2': [math.e, math.e ** 2, math.e ** 3],
+        'feat3': [1.5, 2.5, 3.5],
+        'target': [1, 4, 9]
     })
 
     transformer_fn, data, log = custom_transformer(input_df, ["target"], sqrt)
@@ -519,6 +526,30 @@ def test_custom_transformer():
 
     # the transformed input df should contain the squared value of the feat1 column
     assert expected2.equals(data)
+
+    expected3 = pd.DataFrame({
+        'feat1': [1, 2, 3],
+        'feat2': [1.0, 2.0, 3.0],
+        'feat3': [1.5, 2.5, 3.5],
+        'target': [1, 4, 9]
+    })
+
+    expected4 = pd.DataFrame({
+        'feat1': [1, 2, 3],
+        'feat2': [math.e, math.e ** 2, math.e ** 3],
+        'feat3': [1.0, 2.0, 3.0],
+        'target': [1, 4, 9]
+    })
+
+    transformer_fn, data, log = custom_transformer(input_df, ["feat2"], ln, is_vectorized=True)
+
+    # the transformed input df should contain the square root of the target column
+    assert expected3.equals(data)
+
+    transformer_fn, data, log = custom_transformer(input_df, ["feat3"], floor, is_vectorized=True)
+
+    # the transformed input df should contain the squared value of the feat1 column
+    assert expected4.equals(data)
 
 
 def test_null_injector():


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [X] Documentation
- [X] Tests added and passed

### Background context
The function `fklearn.training.transformation.custom_transformer` had two issues, it had side-effects (dataframe change was inplace) and also misused `transformation_function` if it was a vectorized function, for instance from numpy. This pull request aims to fix both of these issues.