### PR TITLE
Add shap multiclass support

### DIFF
--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -39,7 +39,7 @@ def logistic_classification_learner(df: pd.DataFrame,
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be discrete, since this is a classification model.
 
     params : dict
         The LogisticRegression parameters in the format {"par_name": param}. See:
@@ -126,7 +126,7 @@ def xgb_classification_learner(df: pd.DataFrame,
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be discrete, since this is a classification model.
 
     learning_rate : float
         Float in the range (0, 1]
@@ -259,7 +259,7 @@ def catboost_classification_learner(df: pd.DataFrame,
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be discrete, since this is a classification model.
 
     learning_rate : float
         Float in the range (0, 1]
@@ -392,7 +392,7 @@ def nlp_logistic_classification_learner(df: pd.DataFrame,
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be discrete, since this is a classification model.
 
     vectorizer_params : dict
         The TfidfVectorizer parameters in the format {"par_name": param}. See:
@@ -488,7 +488,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be discrete, since this is a classification model.
 
     learning_rate : float
         Float in the range (0, 1]

--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -188,16 +188,24 @@ def xgb_classification_learner(df: pd.DataFrame,
         if apply_shap:
             import shap
             explainer = shap.TreeExplainer(bst)
-            shap_values = list(explainer.shap_values(new_df[features]))
+            shap_values = explainer.shap_values(new_df[features])
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
-
             if params["objective"] == "multi:softprob":
-                raise NotImplementedError("SHAP values are not implemented for multiclass XGBoost in fklearn")
+                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                                          for (class_index, value) in enumerate(shap_values)}
+                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  for (class_index, (expected_value, class_shap_values))
+                                                  in enumerate(zip(shap_expected_value, shap_values))}
+                shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)
+
             else:
-                col_dict = merge(col_dict, shap_output)
+                shap_values = list(shap_values)
+                shap_output = {"shap_values": shap_values,
+                               "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+
+            col_dict = merge(col_dict, shap_output)
 
         return new_df.assign(**col_dict)
 
@@ -318,11 +326,22 @@ def catboost_classification_learner(df: pd.DataFrame,
         if apply_shap:
             import shap
             explainer = shap.TreeExplainer(cbr)
-            shap_values = list(explainer.shap_values(dtest))
+            shap_values = explainer.shap_values(dtest)
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+            if params["objective"] == "MultiClass":
+                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                                          for (class_index, value) in enumerate(shap_values)}
+                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  for (class_index, (expected_value, class_shap_values))
+                                                  in enumerate(zip(shap_expected_value, shap_values))}
+                shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)
+
+            else:
+                shap_values = list(shap_values)
+                shap_output = {"shap_values": shap_values,
+                               "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
 
             col_dict = merge(col_dict, shap_output)
 
@@ -526,16 +545,24 @@ def lgbm_classification_learner(df: pd.DataFrame,
         if apply_shap:
             import shap
             explainer = shap.TreeExplainer(bst)
-            shap_values = list(explainer.shap_values(new_df[features]))
+            shap_values = explainer.shap_values(new_df[features])
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
-
             if params["objective"] == "multiclass":
-                raise NotImplementedError("SHAP values are not implemented for multiclass LGBM in fkit-learn")
+                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                                          for (class_index, value) in enumerate(shap_values)}
+                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  for (class_index, (expected_value, class_shap_values))
+                                                  in enumerate(zip(shap_expected_value, shap_values))}
+                shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)
+
             else:
-                col_dict = merge(col_dict, shap_output)
+                shap_values = list(shap_values)
+                shap_output = {"shap_values": shap_values,
+                               "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+
+            col_dict = merge(col_dict, shap_output)
 
         return new_df.assign(**col_dict)
 

--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -195,7 +195,7 @@ def xgb_classification_learner(df: pd.DataFrame,
                 shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
                                           for (class_index, value) in enumerate(shap_values)}
                 shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
-                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}
                 shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)
@@ -333,7 +333,7 @@ def catboost_classification_learner(df: pd.DataFrame,
                 shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
                                           for (class_index, value) in enumerate(shap_values)}
                 shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
-                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}
                 shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)
@@ -552,7 +552,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
                 shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
                                           for (class_index, value) in enumerate(shap_values)}
                 shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
-                                                      np.repeat(expected_value, len(class_shap_values))
+                                                  np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}
                 shap_output = merge(shap_values_multiclass, shap_expected_value_multiclass)

--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -192,9 +192,9 @@ def xgb_classification_learner(df: pd.DataFrame,
             shap_expected_value = explainer.expected_value
 
             if params["objective"] == "multi:softprob":
-                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                shap_values_multiclass = {f"shap_values_{class_index}": list(value)
                                           for (class_index, value) in enumerate(shap_values)}
-                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                shap_expected_value_multiclass = {f"shap_expected_value_{class_index}":
                                                   np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}
@@ -330,9 +330,9 @@ def catboost_classification_learner(df: pd.DataFrame,
             shap_expected_value = explainer.expected_value
 
             if params["objective"] == "MultiClass":
-                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                shap_values_multiclass = {f"shap_values_{class_index}": list(value)
                                           for (class_index, value) in enumerate(shap_values)}
-                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                shap_expected_value_multiclass = {f"shap_expected_value_{class_index}":
                                                   np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}
@@ -549,9 +549,9 @@ def lgbm_classification_learner(df: pd.DataFrame,
             shap_expected_value = explainer.expected_value
 
             if params["objective"] == "multiclass":
-                shap_values_multiclass = {"shap_values_" + str(class_index): list(value)
+                shap_values_multiclass = {f"shap_values_{class_index}": list(value)
                                           for (class_index, value) in enumerate(shap_values)}
-                shap_expected_value_multiclass = {"shap_expected_value_" + str(class_index):
+                shap_expected_value_multiclass = {f"shap_expected_value_{class_index}":
                                                   np.repeat(expected_value, len(class_shap_values))
                                                   for (class_index, (expected_value, class_shap_values))
                                                   in enumerate(zip(shap_expected_value, shap_values))}

--- a/tests/training/test_classification.py
+++ b/tests/training/test_classification.py
@@ -139,7 +139,7 @@ def test_xgb_classification_learner():
     assert pred_test_binary.prediction.min() > 0
     assert (pred_test_binary.columns == pred_train_binary.columns).all()
 
-    # SHAP test (binary only)
+    # SHAP test
     pred_shap = predict_fn_binary(df_test_binary, apply_shap=True)
     assert "shap_values" in pred_shap.columns
     assert "shap_expected_value" in pred_shap.columns
@@ -168,6 +168,14 @@ def test_xgb_classification_learner():
     assert Counter(expected_col_train) == Counter(pred_train_multinomial.columns.tolist())
     assert Counter(expected_col_test) == Counter(pred_test_multinomial.columns.tolist())
     assert (pred_test_multinomial.columns == pred_train_multinomial.columns).all()
+
+    # SHAP test multinomial
+    pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
+
+    expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
+                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+    assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
+    assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)
 
 
 def test_catboost_classification_learner():
@@ -250,7 +258,7 @@ def test_catboost_classification_learner():
     assert pred_test_binary.prediction.min() > 0
     assert (pred_test_binary.columns == pred_train_binary.columns).all()
 
-    # SHAP test (binary only)
+    # SHAP test
     pred_shap = predict_fn_binary(df_test_binary, apply_shap=True)
     assert "shap_values" in pred_shap.columns
     assert "shap_expected_value" in pred_shap.columns
@@ -277,6 +285,14 @@ def test_catboost_classification_learner():
     assert Counter(expected_col_train) == Counter(pred_train_multinomial.columns.tolist())
     assert Counter(expected_col_test) == Counter(pred_test_multinomial.columns.tolist())
     assert (pred_test_multinomial.columns == pred_train_multinomial.columns).all()
+
+    # SHAP test multinomial
+    pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
+
+    expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
+                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+    assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
+    assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)
 
     # test categorical case
     features = ["x1", "x2", "x3", "x4", "x5", "x6"]
@@ -431,7 +447,7 @@ def test_lgbm_classification_learner():
     assert pred_test_binary.prediction.min() > 0
     assert (pred_test_binary.columns == pred_train_binary.columns).all()
 
-    # SHAP test (binary only)
+    # SHAP test
     pred_shap = predict_fn_binary(df_test_binary, apply_shap=True)
     assert "shap_values" in pred_shap.columns
     assert "shap_expected_value" in pred_shap.columns
@@ -458,3 +474,11 @@ def test_lgbm_classification_learner():
     assert Counter(expected_col_train) == Counter(pred_train_multinomial.columns.tolist())
     assert Counter(expected_col_test) == Counter(pred_test_multinomial.columns.tolist())
     assert (pred_test_multinomial.columns == pred_train_multinomial.columns).all()
+
+    # SHAP test multinomial
+    pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
+
+    expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
+                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+    assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
+    assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)

--- a/tests/training/test_classification.py
+++ b/tests/training/test_classification.py
@@ -173,7 +173,7 @@ def test_xgb_classification_learner():
     pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
 
     expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
-                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
     assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
     assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)
 
@@ -290,7 +290,7 @@ def test_catboost_classification_learner():
     pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
 
     expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
-                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
     assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
     assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)
 
@@ -479,6 +479,6 @@ def test_lgbm_classification_learner():
     pred_shap_multinomial = predict_fn_multinomial(df_test_multinomial, apply_shap=True)
 
     expected_col_shap = expected_col_test + ["shap_values_0", "shap_values_1", "shap_values_2"] + \
-                        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
+        ["shap_expected_value_0", "shap_expected_value_1", "shap_expected_value_2"]
     assert Counter(expected_col_shap) == Counter(pred_shap_multinomial.columns.tolist())
     assert np.vstack(pred_shap_multinomial["shap_values_0"]).shape == (6, 2)


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
Fklearn supports returning SHAP values on prediction for binary classification and regression, but not for multiclass classification, even though it is supported by SHAP. This PR adds shap multiclass support, using the same approach for naming shap values columns as the one used for prediction columns.
