### PR TITLE
Remove useless requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,5 @@ statsmodels>=0.9.0,<1
 toolz>=0.9.0,<1
 tqdm>=4.32.1,<4.33.0
 xgboost>=0.81,<0.90
-scikit-image>=0.14.2,<0.15.0
 swifter>=0.284,<0.300
 scipy>=1.2.1,<1.3.0


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Tests added and passed
- [x] Issue: closes #80

### Background context
Useless dependency is breaking 1.14.x installation

### Description of the changes proposed in the pull request
Just remove scikit-image requirement