### PR TITLE
Removing scikit-image dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ statsmodels>=0.9.0,<1
 toolz>=0.9.0,<1
 tqdm>=4.32.1,<4.33.0
 xgboost>=0.81,<0.90
-scikit-image>=0.14.2,<0.15.0
 swifter>=0.284,<0.300
 catboost>=0.14.2,<0.15.0
 scipy>=1.2.1,<1.3.0


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [ ] Documentation
- [ ] Tests added and passed
- [ ] Issue: closes #80 

### Background context
Scikit-image dependency is breaking the fklearn installation.

### Description of the changes proposed in the pull request
This PR removes a useless requirement that was breaking fklearn installation.

### Related PRs.
https://github.com/nubank/fklearn/pull/82