### PR TITLE
Fix bug with space_time_split_dataset fn

### DIFF
--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -124,14 +124,14 @@ def space_time_split_dataset(dataset: pd.DataFrame,
         The out of ID sample and in time hold out set.
 
     outime_inspace_hdout : pandas.DataFrame
-        The out of ID sample and in time hold out set.
+        The in ID sample and out of time hold out set.
 
-    holdout_space : pandas.DataFrame
-        The out of ID sample and in time hold out set.
+    outime_outspace_hdout : pandas.DataFrame
+        The out of ID sample and out of time hold out set.
     """
     train_period = dataset[
         (dataset[time_column] >= train_start_date) & (dataset[time_column] < train_end_date)]
-    outime_inspace_hdout = dataset[
+    outime_hdout = dataset[
         (dataset[time_column] >= train_end_date) & (dataset[time_column] < holdout_end_date)]
 
     if holdout_space is None:
@@ -149,6 +149,7 @@ def space_time_split_dataset(dataset: pd.DataFrame,
 
     train_set = train_period[~train_period[space_column].isin(holdout_space)]
     intime_outspace_hdout = train_period[train_period[space_column].isin(holdout_space)]
-    outime_outspace_hdout = outime_inspace_hdout[outime_inspace_hdout[space_column].isin(holdout_space)]
+    outime_outspace_hdout = outime_hdout[outime_hdout[space_column].isin(holdout_space)]
+    outime_inspace_hdout = outime_hdout[~outime_hdout[space_column].isin(holdout_space)]
 
     return train_set, intime_outspace_hdout, outime_inspace_hdout, outime_outspace_hdout

--- a/tests/preprocessing/test_splitting.py
+++ b/tests/preprocessing/test_splitting.py
@@ -35,7 +35,7 @@ def test_time_split_dataset(test_df=df):
 
 
 def test_space_time_split_dataset(test_df=df):
-    train_set, intime_holdout, holdout_period, holdout_space_time = \
+    train_set, intime_outspace_hdout, outime_inspace_hdout, outime_outspace_hdout = \
         space_time_split_dataset(dataset=test_df,
                                  train_start_date="2016-10-01",
                                  train_end_date="2016-11-01",
@@ -45,36 +45,29 @@ def test_space_time_split_dataset(test_df=df):
                                  space_column="space",
                                  time_column="time")
 
-    expected_train = pd.DataFrame(
-        {
-            'space': ['space2'],
-            'time': [pd.to_datetime("2016-10-01")]
-        }
-    )
+    expected_train = pd.DataFrame({
+        'space': ['space2'],
+        'time': [pd.to_datetime("2016-10-01")]
+    })
 
-    expected_intime_holdout = pd.DataFrame({
+    expected_intime_outspace_holdout = pd.DataFrame({
         'space': ['space1'],
         'time': [pd.to_datetime("2016-10-01")]
     })
 
-    expected_holdout_period = pd.DataFrame(
-        {
-            'space': ['space1', 'space2'],
-            'time': [pd.to_datetime("2016-11-01"),
-                     pd.to_datetime("2016-11-01")]
+    expected_outime_outspace_holdout = pd.DataFrame({
+        'space': ['space1'],
+        'time': [pd.to_datetime("2016-11-01")]
 
-        }
-    )
+    })
 
-    expected_holdout_space_time = pd.DataFrame(
-        {
-            'space': ['space1'],
-            'time': [pd.to_datetime("2016-11-01")]
+    expected_outime_inspace_holdout = pd.DataFrame({
+        'space': ['space2'],
+        'time': [pd.to_datetime("2016-11-01")]
 
-        }
-    )
+    })
 
     assert train_set.reset_index(drop=True).equals(expected_train)
-    assert intime_holdout.reset_index(drop=True).equals(expected_intime_holdout)
-    assert holdout_period.reset_index(drop=True).equals(expected_holdout_period)
-    assert holdout_space_time.reset_index(drop=True).equals(expected_holdout_space_time)
+    assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
+    assert outime_inspace_hdout.reset_index(drop=True).equals(expected_outime_inspace_holdout)
+    assert outime_outspace_hdout.reset_index(drop=True).equals(expected_outime_outspace_holdout)


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [X] Tests added and passed
- [X] Issue: closes #91 

### Background context
`space_time_split_dataset` has a bug with how it handles `outime_inspace_hdout` split.

### Description of the changes proposed in the pull request
This PR changes the previous `outime_inspace_hdout` to `outime_hdout` and fixes the function returns. It also fixes this function tests and changes some variable names so it becomes more consistent to what was defined inside the function.