### PR TITLE
Adding PR AUC evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# Visual Studio Code
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -185,7 +185,8 @@ Evaluators (fklearn.validation.evaluators)
 .. currentmodule:: fklearn.validation.evaluators
 
 .. autosummary::
-   auc_evaluator
+   roc_auc_evaluator
+   pr_auc_evaluator
    brier_score_evaluator
    combined_evaluators
    correlation_evaluator

--- a/docs/source/examples/causal_inference.ipynb
+++ b/docs/source/examples/causal_inference.ipynb
@@ -28,7 +28,7 @@
     "from fklearn.training.regression import xgb_regression_learner\n",
     "from fklearn.training.classification import xgb_classification_learner, logistic_classification_learner\n",
     "from fklearn.training.causal_inference import IPTW_learner\n",
-    "from fklearn.validation.evaluators import r2_evaluator, auc_evaluator\n",
+    "from fklearn.validation.evaluators import r2_evaluator, roc_auc_evaluator\n",
     "from fklearn.data.datasets import make_confounded_data\n",
     "\n",
     "from sklearn.model_selection import train_test_split\n",
@@ -586,8 +586,8 @@
     {
      "data": {
       "text/plain": [
-       "({'auc_evaluator__medication': 0.9780837845595602},\n",
-       " {'auc_evaluator__medication': 0.976750491771322})"
+       "({'roc_auc_evaluator__medication': 0.9780837845595602},\n",
+       " {'roc_auc_evaluator__medication': 0.976750491771322})"
       ]
      },
      "execution_count": 15,
@@ -596,7 +596,7 @@
     }
    ],
    "source": [
-    "ps_eval_fn = auc_evaluator(prediction_column=\"propensity_score\", target_column=\"medication\")\n",
+    "ps_eval_fn = roc_auc_evaluator(prediction_column=\"propensity_score\", target_column=\"medication\")\n",
     "ps_eval_fn(train_pred), ps_eval_fn(test_pred) "
    ]
   },

--- a/docs/source/examples/learning_curves.rst
+++ b/docs/source/examples/learning_curves.rst
@@ -50,7 +50,7 @@ but receives as arguments the ones that were not passed previously.
                                                                    freq='M') # split month by month
 
   # define the metric that should be evaluated. For this example, we use AUC
-  eval_fn = evaluators.auc_evaluator(prediction_column=NAME_FOR_PREDICTION_COL,
+  eval_fn = evaluators.roc_auc_evaluator(prediction_column=NAME_FOR_PREDICTION_COL,
                                      target_column=NAME_FOR_TARGET_COL)
 
   # output training logs for the different training ends

--- a/src/fklearn/tuning/parameter_tuners.py
+++ b/src/fklearn/tuning/parameter_tuners.py
@@ -65,7 +65,7 @@ def random_search_tuner(space: LogType,
 
     eval_fn : function(dataset) -> eval_log
         A base evaluation function that returns a simple evaluation log. Can't be a spited or the extractor won't work.
-        Example: auc_evaluator(target_column="target")
+        Example: roc_auc_evaluator(target_column="target")
 
     iterations : int
         The number of iterations to run the parameter tuner
@@ -156,7 +156,7 @@ def grid_search_cv(space: LogType,
 
     eval_fn : function(dataset) -> eval_log
         A base evaluation function that returns a simple evaluation log. Can't be a spited or the extractor won't work.
-        Example: auc_evaluator(target_column="target")
+        Example: roc_auc_evaluator(target_column="target")
 
     save_intermediary_fn : function(log) -> save to file
         Partially defined saver function that receives a log result from a

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Callable, Iterable, List
 
 import numpy as np
@@ -49,6 +50,41 @@ def generic_sklearn_evaluator(name_prefix: str, sklearn_metric: Callable[..., fl
         return {eval_name: score}
 
     return p
+
+
+@curry
+def auc_evaluator(test_data: pd.DataFrame,
+                  prediction_column: str = "prediction",
+                  target_column: str = "target",
+                  eval_name: str = None) -> EvalReturnType:
+    """
+    Computes the ROC AUC score, given true label and prediction scores.
+
+    Parameters
+    ----------
+    test_data : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
+
+    prediction_column : Strings
+        The name of the column in `test_data` with the prediction scores.
+
+    target_column : String
+        The name of the column in `test_data` with the binary target.
+
+    eval_name : String, optional (default=None)
+        the name of the evaluator as it will appear in the logs.
+
+    Returns
+    ----------
+    log: dict
+        A log-like dictionary with the ROC AUC Score
+    """
+
+    warnings.warn("The method `auc_evaluator` will be renamed to `roc_auc_evaluator` in the next major release 2.0.0."
+                  " Please use `roc_auc_evaluator` instead of `auc_evaluator` for Area Under the Curve of the"
+                  " Receiver Operating Characteristics curve.")
+
+    return roc_auc_evaluator(test_data, prediction_column, target_column, eval_name)
 
 
 @curry

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,9 +12,9 @@ LOGS = [
             }
         },
         'validator_log': [
-            {'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.6}],
+            {'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
              'split_log': {'train_size': 8, 'test_size': 8}},
-            {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.6}],
+            {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
              'split_log': {'train_size': 8, 'test_size': 8}}],
         'used_subsets': ['first', 'third']},
     {'train_log':
@@ -27,9 +27,9 @@ LOGS = [
                                            'feature_importance': {'x1': 8, 'x5': 2, 'x3': 3, 'x6': 1, 'x2': 1},
                                            'training_samples': 8, 'running_time': '0.019 s'}
         },
-        'validator_log': [{'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 1.0}],
+        'validator_log': [{'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 1.0}],
                            'split_log': {'train_size': 8, 'test_size': 8}},
-                          {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.8}],
+                          {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.8}],
                            'split_log': {'train_size': 8, 'test_size': 8}}],
         'used_subsets': ['first', 'second']
      }
@@ -48,9 +48,9 @@ PARALLEL_LOGS = [
                                            'training_samples': 8, 'running_time': '0.019 s'}
         },
         'validator_log': [
-            {'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.5}],
+            {'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.5}],
              'split_log': {'train_size': 8, 'test_size': 8}},
-            {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.5}],
+            {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.5}],
              'split_log': {'train_size': 8, 'test_size': 8}}],
         'used_subsets': ['first', 'second', 'third']},
         {'train_log':
@@ -63,9 +63,9 @@ PARALLEL_LOGS = [
                                                'feature_importance': {'x1': 8, 'x5': 2, 'x3': 3, 'x6': 1, 'x2': 1},
                                                'training_samples': 8, 'running_time': '0.019 s'}
             },
-            'validator_log': [{'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.7}],
+            'validator_log': [{'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.7}],
                                'split_log': {'train_size': 8, 'test_size': 8}},
-                              {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.7}],
+                              {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.7}],
                                'split_log': {'train_size': 8, 'test_size': 8}}],
             'used_subsets': ['first', 'second', 'third']}
      ],
@@ -80,9 +80,9 @@ PARALLEL_LOGS = [
                                            'training_samples': 8, 'running_time': '0.019 s'}
         },
         'validator_log': [
-            {'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.6}],
+            {'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
              'split_log': {'train_size': 8, 'test_size': 8}},
-            {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.6}],
+            {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
              'split_log': {'train_size': 8, 'test_size': 8}}],
         'used_subsets': ['first', 'second', 'third']},
         {'train_log': {
@@ -93,9 +93,9 @@ PARALLEL_LOGS = [
                                                           'min_child_weight': 0, 'lambda': 0, 'eta': 1},
                                            'feature_importance': {'x1': 8, 'x5': 2, 'x3': 3, 'x6': 1, 'x2': 1},
                                            'training_samples': 8, 'running_time': '0.019 s'}},
-            'validator_log': [{'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 1.0}],
+            'validator_log': [{'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 1.0}],
                                'split_log': {'train_size': 8, 'test_size': 8}},
-                              {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.8}],
+                              {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.8}],
                                'split_log': {'train_size': 8, 'test_size': 8}}],
             'used_subsets': ['first', 'second', 'third']}
      ]

--- a/tests/tuning/test_parameter_tuners.py
+++ b/tests/tuning/test_parameter_tuners.py
@@ -4,7 +4,7 @@ from toolz import curry
 
 from fklearn.training.classification import xgb_classification_learner
 from fklearn.tuning.parameter_tuners import random_search_tuner, grid_search_cv
-from fklearn.validation.evaluators import auc_evaluator
+from fklearn.validation.evaluators import roc_auc_evaluator
 from fklearn.validation.splitters import out_of_time_and_space_splitter
 
 
@@ -16,7 +16,7 @@ def test_random_search_tuner(tmpdir):
         'target': [0, 1, 0, 1]
     })
 
-    eval_fn = auc_evaluator(target_column="target")
+    eval_fn = roc_auc_evaluator(target_column="target")
 
     space = {
         'learning_rate': lambda: np.random.choice([1e-3, 1e-2, 1e-1, 1, 10]),
@@ -51,7 +51,7 @@ def test_grid_search_tuner(tmpdir):
         'target': [0, 1, 0, 1]
     })
 
-    eval_fn = auc_evaluator(target_column="target")
+    eval_fn = roc_auc_evaluator(target_column="target")
 
     space = {
         'learning_rate': lambda: [1e-3, 1e-2, 1e-1],

--- a/tests/tuning/test_samplers.py
+++ b/tests/tuning/test_samplers.py
@@ -1,14 +1,14 @@
+import pandas as pd
 import pytest
+from tests import LOGS, PARALLEL_LOGS
 from toolz.curried import first
 
 from fklearn.metrics.pd_extractors import evaluator_extractor
 from fklearn.training.classification import logistic_classification_learner
-from fklearn.tuning.samplers import \
-    remove_by_feature_importance, remove_features_subsets, remove_by_feature_shuffling
-from fklearn.validation.evaluators import auc_evaluator
-import pandas as pd
-
-from tests import LOGS, PARALLEL_LOGS
+from fklearn.tuning.samplers import (remove_by_feature_importance,
+                                     remove_by_feature_shuffling,
+                                     remove_features_subsets)
+from fklearn.validation.evaluators import roc_auc_evaluator
 
 
 @pytest.fixture()
@@ -23,12 +23,12 @@ def parallel_logs():
 
 @pytest.fixture()
 def base_extractor():
-    return evaluator_extractor(evaluator_name='auc_evaluator__target')
+    return evaluator_extractor(evaluator_name='roc_auc_evaluator__target')
 
 
 @pytest.fixture()
 def metric_name():
-    return 'auc_evaluator__target'
+    return 'roc_auc_evaluator__target'
 
 
 @pytest.fixture()
@@ -97,7 +97,7 @@ def train_fn():
 
 @pytest.fixture()
 def eval_fn():
-    return auc_evaluator
+    return roc_auc_evaluator
 
 
 def test_remove_by_feature_importance(logs):

--- a/tests/tuning/test_selectors.py
+++ b/tests/tuning/test_selectors.py
@@ -8,7 +8,7 @@ from fklearn.training.classification import logistic_classification_learner
 from fklearn.tuning.utils import get_used_features
 from fklearn.tuning.selectors import \
     feature_importance_backward_selection, poor_man_boruta_selection, backward_subset_feature_selection
-from fklearn.validation.evaluators import auc_evaluator
+from fklearn.validation.evaluators import roc_auc_evaluator
 from fklearn.validation.splitters import k_fold_splitter
 
 from tests import LOGS, PARALLEL_LOGS
@@ -26,12 +26,12 @@ def parallel_logs():
 
 @pytest.fixture()
 def base_extractor():
-    return evaluator_extractor(evaluator_name='auc_evaluator__target')
+    return evaluator_extractor(evaluator_name='roc_auc_evaluator__target')
 
 
 @pytest.fixture()
 def metric_name():
-    return 'auc_evaluator__target'
+    return 'roc_auc_evaluator__target'
 
 
 @pytest.fixture()
@@ -100,7 +100,7 @@ def train_fn():
 
 @pytest.fixture()
 def eval_fn():
-    return auc_evaluator
+    return roc_auc_evaluator
 
 
 @pytest.fixture()

--- a/tests/tuning/test_stoppers.py
+++ b/tests/tuning/test_stoppers.py
@@ -20,12 +20,12 @@ def parallel_logs():
 
 @pytest.fixture()
 def base_extractor():
-    return evaluator_extractor(evaluator_name='auc_evaluator__target')
+    return evaluator_extractor(evaluator_name='roc_auc_evaluator__target')
 
 
 @pytest.fixture()
 def metric_name():
-    return 'auc_evaluator__target'
+    return 'roc_auc_evaluator__target'
 
 
 def test_stop_by_iter_num(logs):

--- a/tests/tuning/test_utils.py
+++ b/tests/tuning/test_utils.py
@@ -22,9 +22,9 @@ def logs():
                                                'training_samples': 8, 'running_time': '0.019 s'}
             },
          'validator_log': [
-             {'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.8}],
+             {'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.8}],
               'split_log': {'train_size': 8, 'test_size': 8}},
-             {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.8}],
+             {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.8}],
               'split_log': {'train_size': 8, 'test_size': 8}}],
          'used_subsets': ['first', 'second']},
         {'train_log':
@@ -38,9 +38,9 @@ def logs():
                                                'training_samples': 8, 'running_time': '0.019 s'}
             },
          'validator_log': [
-             {'fold_num': 0, 'eval_results': [{'auc_evaluator__target': 0.6}],
+             {'fold_num': 0, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
               'split_log': {'train_size': 8, 'test_size': 8}},
-             {'fold_num': 1, 'eval_results': [{'auc_evaluator__target': 0.6}],
+             {'fold_num': 1, 'eval_results': [{'roc_auc_evaluator__target': 0.6}],
               'split_log': {'train_size': 8, 'test_size': 8}}],
          'used_subsets': ['first', 'third']}
     ]
@@ -48,12 +48,12 @@ def logs():
 
 @pytest.fixture()
 def base_extractor():
-    return evaluator_extractor(evaluator_name='auc_evaluator__target')
+    return evaluator_extractor(evaluator_name='roc_auc_evaluator__target')
 
 
 @pytest.fixture()
 def metric_name():
-    return 'auc_evaluator__target'
+    return 'roc_auc_evaluator__target'
 
 
 @pytest.fixture()

--- a/tests/validation/test_evaluators.py
+++ b/tests/validation/test_evaluators.py
@@ -5,12 +5,13 @@ import pandas as pd
 import pytest
 
 from fklearn.validation.evaluators import (
-    brier_score_evaluator, combined_evaluators, correlation_evaluator,
-    expected_calibration_error_evaluator, fbeta_score_evaluator,
-    hash_evaluator, logloss_evaluator, mean_prediction_evaluator,
-    mse_evaluator, permutation_evaluator, pr_auc_evaluator,
-    precision_evaluator, r2_evaluator, recall_evaluator, roc_auc_evaluator,
-    spearman_evaluator, split_evaluator, temporal_split_evaluator)
+    auc_evaluator, brier_score_evaluator, combined_evaluators,
+    correlation_evaluator, expected_calibration_error_evaluator,
+    fbeta_score_evaluator, hash_evaluator, logloss_evaluator,
+    mean_prediction_evaluator, mse_evaluator, permutation_evaluator,
+    pr_auc_evaluator, precision_evaluator, r2_evaluator, recall_evaluator,
+    roc_auc_evaluator, spearman_evaluator, split_evaluator,
+    temporal_split_evaluator)
 
 
 def test_combined_evaluators():
@@ -43,6 +44,23 @@ def test_mean_prediction_evaluator():
     result = eval_fn(predictions)
 
     assert result["eval_name"] == (1 + 0.9 + 40) / 3
+
+
+def test_auc_evaluator():
+    predictions = pd.DataFrame(
+        {
+            'target': [0, 1, 0, 1],
+            'prediction': [.2, .9, .3, .3]
+        }
+    )
+
+    eval_fn = auc_evaluator(prediction_column="prediction",
+                            target_column="target",
+                            eval_name="eval_name")
+
+    result = eval_fn(predictions)
+
+    assert result["eval_name"] == 0.875
 
 
 def test_roc_auc_evaluator():

--- a/tests/validation/test_evaluators.py
+++ b/tests/validation/test_evaluators.py
@@ -2,12 +2,15 @@ import string
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from fklearn.validation.evaluators import \
-    r2_evaluator, mse_evaluator, combined_evaluators, mean_prediction_evaluator, auc_evaluator, \
-    precision_evaluator, recall_evaluator, fbeta_score_evaluator, logloss_evaluator, brier_score_evaluator, \
-    expected_calibration_error_evaluator, correlation_evaluator, spearman_evaluator, split_evaluator, \
-    temporal_split_evaluator, permutation_evaluator, hash_evaluator
+from fklearn.validation.evaluators import (
+    brier_score_evaluator, combined_evaluators, correlation_evaluator,
+    expected_calibration_error_evaluator, fbeta_score_evaluator,
+    hash_evaluator, logloss_evaluator, mean_prediction_evaluator,
+    mse_evaluator, permutation_evaluator, pr_auc_evaluator,
+    precision_evaluator, r2_evaluator, recall_evaluator, roc_auc_evaluator,
+    spearman_evaluator, split_evaluator, temporal_split_evaluator)
 
 
 def test_combined_evaluators():
@@ -42,7 +45,7 @@ def test_mean_prediction_evaluator():
     assert result["eval_name"] == (1 + 0.9 + 40) / 3
 
 
-def test_auc_evaluator():
+def test_roc_auc_evaluator():
     predictions = pd.DataFrame(
         {
             'target': [0, 1, 0, 1],
@@ -50,13 +53,30 @@ def test_auc_evaluator():
         }
     )
 
-    eval_fn = auc_evaluator(prediction_column="prediction",
-                            target_column="target",
-                            eval_name="eval_name")
+    eval_fn = roc_auc_evaluator(prediction_column="prediction",
+                                target_column="target",
+                                eval_name="eval_name")
 
     result = eval_fn(predictions)
 
     assert result["eval_name"] == 0.875
+
+
+def test_pr_auc_evaluator():
+    predictions = pd.DataFrame(
+        {
+            'target': [0, 1, 0, 1],
+            'prediction': [.2, .9, .3, .3]
+        }
+    )
+
+    eval_fn = pr_auc_evaluator(prediction_column="prediction",
+                               target_column="target",
+                               eval_name="eval_name")
+
+    result = eval_fn(predictions)
+
+    assert result["eval_name"] == pytest.approx(0.833333)
 
 
 def test_precision_evaluator():


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [ ] Documentation
- [ ] Tests added and passed

### Background context
Even though we have ROC AUC evaluator implemented in `fklearn`, we are still missing PR AUC evaluator.

### Description of the changes proposed in the pull request
This PR:
1) Adds a new evaluator `pr_auc_evaluator` 
2) Changes the generic auc evaluator name from `auc_evaluator` to `roc_auc_evaluator`