### PR TITLE
Fix space_time_split_dataset

### DIFF
--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -155,12 +155,13 @@ def space_time_split_dataset(dataset: pd.DataFrame,
         train_period_space = np.sort(all_space_in_time)
 
         # randomly sample accounts from the train period to hold out
-        in_space = state.choice(train_period_space,
-                                int((1 - space_holdout_percentage) * len(train_period_space)),
-                                replace=False)
+        partial_holdout_space = state.choice(train_period_space,
+                                             int(space_holdout_percentage * len(train_period_space)),
+                                             replace=False)
+        in_space = all_space_in_time[~np.isin(all_space_in_time, partial_holdout_space)]
 
     else:
-        in_space = all_space_in_time[~all_space_in_time.isin(holdout_space)]
+        in_space = all_space_in_time[~np.isin(all_space_in_time, holdout_space)]
 
     in_space_mask = dataset[space_column].isin(in_space)
 
@@ -169,4 +170,4 @@ def space_time_split_dataset(dataset: pd.DataFrame,
     outtime_outspace_hdout = dataset[~in_space_mask & out_time_mask]
     outtime_inspace_hdout = dataset[in_space_mask & out_time_mask]
 
-    return train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout
+    return train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout, in_space_mask

--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -170,4 +170,4 @@ def space_time_split_dataset(dataset: pd.DataFrame,
     outtime_outspace_hdout = dataset[~in_space_mask & out_time_mask]
     outtime_inspace_hdout = dataset[in_space_mask & out_time_mask]
 
-    return train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout, in_space_mask
+    return train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout

--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -147,7 +147,7 @@ def space_time_split_dataset(dataset: pd.DataFrame,
     in_time_mask = (dataset[time_column] >= train_start_date) & (dataset[time_column] < train_end_date)
     out_time_mask = (dataset[time_column] >= holdout_start_date) & (dataset[time_column] < holdout_end_date)
 
-    all_space_in_time = dataset[in_time_mask][space_column].unique() # 
+    all_space_in_time = dataset[in_time_mask][space_column].unique()
     
     if holdout_space is None:
         # for repeatability

--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -148,7 +148,7 @@ def space_time_split_dataset(dataset: pd.DataFrame,
     out_time_mask = (dataset[time_column] >= holdout_start_date) & (dataset[time_column] < holdout_end_date)
 
     all_space_in_time = dataset[in_time_mask][space_column].unique()
-    
+
     if holdout_space is None:
         # for repeatability
         state = RandomState(split_seed)
@@ -158,12 +158,12 @@ def space_time_split_dataset(dataset: pd.DataFrame,
         in_space = state.choice(train_period_space,
                                 int((1 - space_holdout_percentage) * len(train_period_space)),
                                 replace=False)
-    
+
     else:
         in_space = all_space_in_time[~all_space_in_time.isin(holdout_space)]
-    
+
     in_space_mask = dataset[space_column].isin(in_space)
-    
+
     train_set = dataset[in_space_mask & in_time_mask]
     intime_outspace_hdout = dataset[~in_space_mask & in_time_mask]
     outtime_outspace_hdout = dataset[~in_space_mask & out_time_mask]

--- a/tests/preprocessing/test_splitting.py
+++ b/tests/preprocessing/test_splitting.py
@@ -7,7 +7,23 @@ df = pd.DataFrame(
         'space': ['space1', 'space2', 'space1', 'space2', 'space1', 'space2'],
         'time': [pd.to_datetime("2016-10-01"), pd.to_datetime("2016-10-01"), pd.to_datetime("2016-11-01"),
                  pd.to_datetime("2016-11-01"), pd.to_datetime("2016-12-01"), pd.to_datetime("2016-12-01")]
+    }
+)
 
+df_with_new_id = pd.DataFrame(
+    {
+        'space': ['space1', 'space2', 'space1', 'space2', 'space1', 'space2', 'space3'],
+        'time': [pd.to_datetime("2016-10-01"), pd.to_datetime("2016-10-01"), pd.to_datetime("2016-11-01"),
+                 pd.to_datetime("2016-11-01"), pd.to_datetime("2016-12-01"), pd.to_datetime("2016-12-01"),
+                 pd.to_datetime("2016-11-01")]
+    }
+)
+
+df_only_one_point_per_id = pd.DataFrame(
+    {
+        'space': ['space1', 'space2', 'space3', 'space4'],
+        'time': [pd.to_datetime("2016-10-01"), pd.to_datetime("2016-10-01"), pd.to_datetime("2016-11-01"),
+                 pd.to_datetime("2016-11-01")]
     }
 )
 
@@ -56,8 +72,11 @@ def test_time_split_dataset(test_df=df):
     assert out_time_test_set.reset_index(drop=True).equals(expected_test)
 
 
-def test_space_time_split_dataset(test_df=df):
-    train_set, intime_outspace_hdout, outime_inspace_hdout, outime_outspace_hdout = \
+def test_space_time_split_dataset(test_df=df,
+                                  test_df_with_new_id=df_with_new_id,
+                                  test_df_only_one_point_per_id=df_only_one_point_per_id):
+
+    train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout = \
         space_time_split_dataset(dataset=test_df,
                                  train_start_date="2016-10-01",
                                  train_end_date="2016-11-01",
@@ -77,13 +96,13 @@ def test_space_time_split_dataset(test_df=df):
         'time': [pd.to_datetime("2016-10-01")]
     })
 
-    expected_outime_outspace_holdout = pd.DataFrame({
+    expected_outtime_outspace_holdout = pd.DataFrame({
         'space': ['space1'],
         'time': [pd.to_datetime("2016-11-01")]
 
     })
 
-    expected_outime_inspace_holdout = pd.DataFrame({
+    expected_outtime_inspace_holdout = pd.DataFrame({
         'space': ['space2'],
         'time': [pd.to_datetime("2016-11-01")]
 
@@ -91,11 +110,11 @@ def test_space_time_split_dataset(test_df=df):
 
     assert train_set.reset_index(drop=True).equals(expected_train)
     assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
-    assert outime_inspace_hdout.reset_index(drop=True).equals(expected_outime_inspace_holdout)
-    assert outime_outspace_hdout.reset_index(drop=True).equals(expected_outime_outspace_holdout)
+    assert outtime_inspace_hdout.reset_index(drop=True).equals(expected_outtime_inspace_holdout)
+    assert outtime_outspace_hdout.reset_index(drop=True).equals(expected_outtime_outspace_holdout)
 
     # Testing optional argument `holdout_start_date`
-    train_set, intime_outspace_hdout, outime_inspace_hdout, outime_outspace_hdout = \
+    train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout = \
         space_time_split_dataset(dataset=test_df,
                                  train_start_date="2016-10-01",
                                  train_end_date="2016-11-01",
@@ -116,13 +135,13 @@ def test_space_time_split_dataset(test_df=df):
         'time': [pd.to_datetime("2016-10-01")]
     })
 
-    expected_outime_outspace_holdout = pd.DataFrame({
+    expected_outtime_outspace_holdout = pd.DataFrame({
         'space': ['space1'],
         'time': [pd.to_datetime("2016-12-01")]
 
     })
 
-    expected_outime_inspace_holdout = pd.DataFrame({
+    expected_outtime_inspace_holdout = pd.DataFrame({
         'space': ['space2'],
         'time': [pd.to_datetime("2016-12-01")]
 
@@ -130,5 +149,75 @@ def test_space_time_split_dataset(test_df=df):
 
     assert train_set.reset_index(drop=True).equals(expected_train)
     assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
-    assert outime_inspace_hdout.reset_index(drop=True).equals(expected_outime_inspace_holdout)
-    assert outime_outspace_hdout.reset_index(drop=True).equals(expected_outime_outspace_holdout)
+    assert outtime_inspace_hdout.reset_index(drop=True).equals(expected_outtime_inspace_holdout)
+    assert outtime_outspace_hdout.reset_index(drop=True).equals(expected_outtime_outspace_holdout)
+
+    # Testing new space id appearing in the holdout period
+    train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout = \
+        space_time_split_dataset(dataset=test_df_with_new_id,
+                                 train_start_date="2016-10-01",
+                                 train_end_date="2016-11-01",
+                                 holdout_end_date="2016-12-01",
+                                 split_seed=1,
+                                 space_holdout_percentage=0.5,
+                                 space_column="space",
+                                 time_column="time")
+
+    expected_train = pd.DataFrame({
+        'space': ['space2'],
+        'time': [pd.to_datetime("2016-10-01")]
+    })
+
+    expected_intime_outspace_holdout = pd.DataFrame({
+        'space': ['space1'],
+        'time': [pd.to_datetime("2016-10-01")]
+    })
+
+    expected_outtime_outspace_holdout = pd.DataFrame({
+        'space': ['space1', 'space3'],
+        'time': [pd.to_datetime("2016-11-01"), pd.to_datetime("2016-11-01")]
+
+    })
+
+    expected_outtime_inspace_holdout = pd.DataFrame({
+        'space': ['space2'],
+        'time': [pd.to_datetime("2016-11-01")]
+
+    })
+
+    assert train_set.reset_index(drop=True).equals(expected_train)
+    assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
+    assert outtime_inspace_hdout.reset_index(drop=True).equals(expected_outtime_inspace_holdout)
+    assert outtime_outspace_hdout.reset_index(drop=True).equals(expected_outtime_outspace_holdout)
+
+    # Testing only one point per space id
+    train_set, intime_outspace_hdout, outtime_inspace_hdout, outtime_outspace_hdout = \
+        space_time_split_dataset(dataset=test_df_only_one_point_per_id,
+                                 train_start_date="2016-10-01",
+                                 train_end_date="2016-11-01",
+                                 holdout_end_date="2016-12-01",
+                                 split_seed=1,
+                                 space_holdout_percentage=0.5,
+                                 space_column="space",
+                                 time_column="time")
+
+    expected_train = pd.DataFrame({
+        'space': ['space2'],
+        'time': [pd.to_datetime("2016-10-01")]
+    })
+
+    expected_intime_outspace_holdout = pd.DataFrame({
+        'space': ['space1'],
+        'time': [pd.to_datetime("2016-10-01")]
+    })
+
+    expected_outtime_outspace_holdout = pd.DataFrame({
+        'space': ['space3', 'space4'],
+        'time': [pd.to_datetime("2016-11-01"), pd.to_datetime("2016-11-01")]
+
+    })
+
+    assert train_set.reset_index(drop=True).equals(expected_train)
+    assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
+    assert outtime_inspace_hdout.empty
+    assert outtime_outspace_hdout.reset_index(drop=True).equals(expected_outtime_outspace_holdout)


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Tests added and passed

### Background context
Function `preprocessing.splitting.space_time_split_dataset` is returning faulty holdout datasets.

Since all datasets are defined in terms of `holdout_space` (which is a random subset of "ids" found in the training period), all new "ids" appearing only in the outtime period will be wrongfully attributed to inspace.

In the limit, when there's just one data point per id, there'll be an inversion of `outtime_inspace` and `outtime_outspace`.

### Description of the changes proposed in the pull request
This PR fixes this by defining everything in terms of `inspace`.