### PR TITLE
Startified split

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ pytest-cov>=2.6.1,<3
 pytest-xdist>=1.26.1,<2
 mypy>=0.670,<1
 codecov>=2.0,<3
+hypothesis>=5.5.4

--- a/tests/preprocessing/test_splitting.py
+++ b/tests/preprocessing/test_splitting.py
@@ -1,6 +1,12 @@
-import pandas as pd
+from collections import Counter
 
-from fklearn.preprocessing.splitting import space_time_split_dataset, time_split_dataset
+import hypothesis.strategies as st
+import pandas as pd
+from hypothesis import given
+from hypothesis.extra.pandas import columns, data_frames, range_indexes
+from pandas.util.testing import assert_frame_equal
+
+from fklearn.preprocessing.splitting import space_time_split_dataset, time_split_dataset, stratified_split_dataset
 
 df = pd.DataFrame(
     {
@@ -26,6 +32,8 @@ df_only_one_point_per_id = pd.DataFrame(
                  pd.to_datetime("2016-11-01")]
     }
 )
+
+MAX_STRATIFIED_SPLIT_SIZE_DIFFERENCE = 1
 
 
 def test_time_split_dataset(test_df=df):
@@ -221,3 +229,51 @@ def test_space_time_split_dataset(test_df=df,
     assert intime_outspace_hdout.reset_index(drop=True).equals(expected_intime_outspace_holdout)
     assert outtime_inspace_hdout.empty
     assert outtime_outspace_hdout.reset_index(drop=True).equals(expected_outtime_outspace_holdout)
+
+
+@st.composite
+def gen_stratified_test_data(draw):
+    column_name_strategy = st.text(st.characters(whitelist_categories=["Lu", "Ll"]), min_size=3)
+    all_column_names = draw(st.lists(column_name_strategy, min_size=3, max_size=6, unique=True))
+    target_column_name = all_column_names[-1]
+
+    column_strategies = columns(all_column_names, dtype=int)
+    data_set = draw(data_frames(column_strategies, index=range_indexes(min_size=50, max_size=100)))
+
+    num_classes = draw(st.integers(min_value=2, max_value=5))
+    data_set[target_column_name] = [i % num_classes for i in range(len(data_set))]
+
+    return data_set, target_column_name, num_classes
+
+
+def assert_sample_size_per_class(data, target_column_name, expected_samples_per_class):
+    count_per_class = Counter(data[target_column_name]).values()
+
+    for count in count_per_class:
+        assert abs(count - expected_samples_per_class) <= MAX_STRATIFIED_SPLIT_SIZE_DIFFERENCE
+
+
+@given(sample=gen_stratified_test_data(),
+       random_state=st.integers(min_value=0, max_value=100),
+       test_size=st.floats(min_value=0.2, max_value=0.8))
+def test_stratified_split_dataset(sample, random_state, test_size):
+    expected_data, target_column_name, num_classes = sample
+
+    train_data, test_data = stratified_split_dataset(expected_data, target_column_name, test_size=test_size,
+                                                     random_state=random_state)
+
+    total_samples = len(expected_data)
+    expected_test_size = int(total_samples * test_size)
+    expected_train_size = total_samples - expected_test_size
+
+    expected_test_samples_per_class = expected_test_size / num_classes
+    expected_train_samples_per_class = expected_train_size / num_classes
+
+    data = pd.concat([train_data, test_data])
+
+    assert abs(len(train_data) - expected_train_size) <= MAX_STRATIFIED_SPLIT_SIZE_DIFFERENCE
+    assert abs(len(test_data) - expected_test_size) <= MAX_STRATIFIED_SPLIT_SIZE_DIFFERENCE
+
+    assert_frame_equal(data, expected_data, check_like=True)
+    assert_sample_size_per_class(train_data, target_column_name, expected_train_samples_per_class)
+    assert_sample_size_per_class(test_data, target_column_name, expected_test_samples_per_class)


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
In some cases data doesn't depend on time or space, but in their class. Therefore, to have a fair evaluation we have to split the data into train and test datasets keeping the same class ratio.

### Description of the changes proposed in the pull request
We introduce an stratified dataset  splitter that can be used during model training.
