### PR TITLE
Add Normalized Discount Cumulative Gain (NDCG) evaluator

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -202,6 +202,7 @@ Evaluators (fklearn.validation.evaluators)
    r2_evaluator
    recall_evaluator
    spearman_evaluator
+   ndcg_evaluator
    split_evaluator
    temporal_split_evaluator
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -635,6 +635,9 @@ def ndcg_evaluator(test_data: pd.DataFrame,
         relevant items. If the relevance of these items is binary values in {0,1}, then the two approaches
         are the same, which is the linear case.
 
+    eval_name : String, optional (default=None)
+        the name of the evaluator as it will appear in the logs.
+
     Returns
     ----------
     log: dict

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -629,7 +629,7 @@ def ndcg_evaluator(test_data: pd.DataFrame,
 
     k : int, optional (default=None)
         The size of the rank that is used to fit (highest k scores) the NDCG score. If None, use all outputs.
-        Note that this value must between [1, +inf].
+        Otherwise, this value must be between [1, len(test_data[prediction_column])].
 
     exponential_gain : bool (default=True)
         If False, then use the linear gain. The exponential gain places a stronger emphasis on retrieving
@@ -642,14 +642,14 @@ def ndcg_evaluator(test_data: pd.DataFrame,
     Returns
     ----------
     log: dict
-        A log-like dictionary with the NDCG score.
+        A log-like dictionary with the NDCG score, float in [0,1].
     """
+
+    if isinstance(k, (int, float)) and not 0 < k <= len(test_data[prediction_column]):
+        raise ValueError("k must be between [1, len(test_data[prediction_column])].")
 
     if eval_name is None:
         eval_name = f"ndcg_evaluator__{target_column}"
-
-    if isinstance(k, int) and k <= 0:
-        raise AttributeError("k value must between [1, +inf].")
 
     rel = np.argsort(test_data[prediction_column])[::-1][:k]
     cum_gain = test_data[target_column][rel]

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -629,6 +629,7 @@ def ndcg_evaluator(test_data: pd.DataFrame,
 
     k : int, optional (default=None)
         The size of the rank that is used to fit (highest k scores) the NDCG score. If None, use all outputs.
+        Note that this value must between [1, +inf].
 
     exponential_gain : bool (default=True)
         If False, then use the linear gain. The exponential gain places a stronger emphasis on retrieving
@@ -636,7 +637,7 @@ def ndcg_evaluator(test_data: pd.DataFrame,
         are the same, which is the linear case.
 
     eval_name : String, optional (default=None)
-        the name of the evaluator as it will appear in the logs.
+        The name of the evaluator as it will appear in the logs.
 
     Returns
     ----------
@@ -646,6 +647,9 @@ def ndcg_evaluator(test_data: pd.DataFrame,
 
     if eval_name is None:
         eval_name = f"ndcg_evaluator__{target_column}"
+
+    if isinstance(k, int) and k <= 0:
+        raise AttributeError("k value must between [1, +inf].")
 
     rel = np.argsort(test_data[prediction_column])[::-1][:k]
     cum_gain = test_data[target_column][rel]

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -604,6 +604,66 @@ def spearman_evaluator(test_data: pd.DataFrame,
 
 
 @curry
+def ndcg_evaluator(test_data: pd.DataFrame,
+                   prediction_column: str = "prediction",
+                   target_column: str = "target",
+                   k: int = None,
+                   exponential_gain: bool = True,
+                   eval_name: str = None) -> EvalReturnType:
+    """
+    Computes the Normalized Discount Cumulative Gain (NDCG) between
+    of the original and predicted rankings:
+    https://en.wikipedia.org/wiki/Discounted_cumulative_gain
+
+    Parameters
+    ----------
+
+    test_data : Pandas DataFrame
+        A Pandas' DataFrame with with target and prediction scores.
+
+    prediction_column : String
+        The name of the column in `test_data` with the prediction scores.
+
+    target_column : String
+        The name of the column in `test_data` with the target.
+
+    k : int, optional (default=None)
+        The size of the rank that is used to fit (highest k scores) the NDCG score. If None, use all outputs.
+
+    exponential_gain : bool (default=True)
+        If False, then use the linear gain. The exponential gain places a stronger emphasis on retrieving
+        relevant items. If the relevance of these items is binary values in {0,1}, then the two approaches
+        are the same, which is the linear case.
+
+    Returns
+    ----------
+    log: dict
+        A log-like dictionary with the NDCG score.
+    """
+
+    if eval_name is None:
+        eval_name = f"ndcg_evaluator__" + target_column
+
+    rel = np.argsort(test_data[prediction_column])[::-1][:k]
+    cum_gain = test_data[target_column][rel]
+
+    ideal_cum_gain = np.sort(test_data[target_column])[::-1][:k]
+
+    if exponential_gain:
+        cum_gain = (2 ** cum_gain) - 1
+        ideal_cum_gain = (2 ** ideal_cum_gain) - 1
+
+    discount = np.log2(np.arange(len(cum_gain)) + 2.0)
+
+    dcg = np.sum(cum_gain / discount)
+    idcg = np.sum(ideal_cum_gain / discount)
+
+    ndcg_score = dcg / idcg
+
+    return {eval_name: ndcg_score}
+
+
+@curry
 def combined_evaluators(test_data: pd.DataFrame,
                         evaluators: List[EvalFnType]) -> EvalReturnType:
     """

--- a/tests/validation/test_evaluators.py
+++ b/tests/validation/test_evaluators.py
@@ -10,7 +10,7 @@ from fklearn.validation.evaluators import (
     fbeta_score_evaluator, hash_evaluator, logloss_evaluator,
     mean_prediction_evaluator, mse_evaluator, permutation_evaluator,
     pr_auc_evaluator, precision_evaluator, r2_evaluator, recall_evaluator,
-    roc_auc_evaluator, spearman_evaluator, split_evaluator,
+    roc_auc_evaluator, spearman_evaluator, ndcg_evaluator, split_evaluator,
     temporal_split_evaluator)
 
 
@@ -275,6 +275,19 @@ def test_spearman_evaluator():
     result = spearman_evaluator(predictions)
 
     assert result['spearman_evaluator__target'] == 1.0
+
+
+def test_ndcg_evaluator():
+    predictions = pd.DataFrame(
+        {
+            'target': [0, 1, 2],
+            'prediction': [0.5, 0.9, 1.5]
+        }
+    )
+
+    result = ndcg_evaluator(predictions)
+
+    assert result['ndcg_evaluator__target'] == 1.0
 
 
 def test_split_evaluator():

--- a/tests/validation/test_evaluators.py
+++ b/tests/validation/test_evaluators.py
@@ -277,16 +277,35 @@ def test_spearman_evaluator():
     assert result['spearman_evaluator__target'] == 1.0
 
 
-def test_ndcg_evaluator():
+@pytest.mark.parametrize("exponential_gain", [False, True])
+def test_ndcg_evaluator(exponential_gain):
     predictions = pd.DataFrame(
         {
-            'target': [0, 1, 2],
-            'prediction': [0.5, 0.9, 1.5]
+            'target': [1.0, 0.5, 1.5],
+            'prediction': [0.9, 0.3, 1.2]
         }
     )
 
-    result = ndcg_evaluator(predictions)
+    result = ndcg_evaluator(
+        predictions,
+        exponential_gain=exponential_gain
+    )
+    assert result['ndcg_evaluator__target'] == 1.0
 
+    k = 0
+    with pytest.raises(AttributeError):
+        ndcg_evaluator(
+            predictions,
+            k=k,
+            exponential_gain=exponential_gain
+        )
+
+    k = 2
+    result = ndcg_evaluator(
+        predictions,
+        k=k,
+        exponential_gain=exponential_gain
+    )
     assert result['ndcg_evaluator__target'] == 1.0
 
 

--- a/tests/validation/test_evaluators.py
+++ b/tests/validation/test_evaluators.py
@@ -286,27 +286,23 @@ def test_ndcg_evaluator(exponential_gain):
         }
     )
 
-    result = ndcg_evaluator(
-        predictions,
-        exponential_gain=exponential_gain
-    )
-    assert result['ndcg_evaluator__target'] == 1.0
+    k_raises = [-1, 0, 4]
+    for k in k_raises:
+        with pytest.raises(ValueError):
+            ndcg_evaluator(
+                predictions,
+                k=k,
+                exponential_gain=exponential_gain
+            )
 
-    k = 0
-    with pytest.raises(AttributeError):
-        ndcg_evaluator(
+    k_not_raises = [None, 1, 2, 3]
+    for k in k_not_raises:
+        result = ndcg_evaluator(
             predictions,
             k=k,
             exponential_gain=exponential_gain
         )
-
-    k = 2
-    result = ndcg_evaluator(
-        predictions,
-        k=k,
-        exponential_gain=exponential_gain
-    )
-    assert result['ndcg_evaluator__target'] == 1.0
+        assert result['ndcg_evaluator__target'] == 1.0
 
 
 def test_split_evaluator():


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context

Currently, in this project exists an only rank evaluator, the Spearman correlation that examines the rank order between two variables. However, if we must measure the **quality** of the two ranks given real and predicted scores, we have to consider using the Normalized Discount Cumulative Gain (NDCG). Here, there are two main motivations [[1]](#1)

  1. Highly relevant items are more useful when appearing earlier in a search – have higher ranks;
  2. Highly relevant items are more useful than marginally relevant items, which are in turn more useful than non-relevant items.

This metric is widely used by recommender systems and information retrieval [[2]](#2).

[[1]](#1) https://en.wikipedia.org/wiki/Discounted_cumulative_gain.

[[2]](#2) BOBADILLA, Jesús et al. Recommender systems survey. Knowledge-based systems, v. 46, p. 109-132, 2013.