### PR TITLE
Fix medication inverse sign

### DIFF
--- a/src/fklearn/data/datasets.py
+++ b/src/fklearn/data/datasets.py
@@ -81,7 +81,7 @@ def make_confounded_data(n: int) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFra
                                         + 0.5 * df["sex"]
                                         + 0.03 * df["age"]
                                         + df["severity"]
-                                        + df["medication"]))
+                                        - df["medication"]))
 
     np.random.seed(1111)
     sexes = np.random.randint(0, 2, size=n)


### PR DESCRIPTION
### Status
**READY**
- READY: development over and everything ready for merging

### Todo list
- [x] Tests passed

### Background context
According to the [causal inference example](https://fklearn.readthedocs.io/en/latest/examples/causal_inference.html), the recovery time should decrease when treatment (medication) equals 1. I believe the plus sign was a typo because the example shows the formula with minus sign for medication. 

### Description of the changes proposed in the pull request
Changes the plus sign with minus sign

### Where should the reviewer start?
`src/fklearn/data/datasets.py`
