### PR TITLE
Documentation: target_categorizer default values

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -109,6 +109,7 @@ Transformation (fklearn.training.transformation)
    rank_categorical
    selector
    standard_scaler
+   target_categorizer
    truncate_categorical
    value_mapper
 

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -747,11 +747,11 @@ def target_categorizer(df: pd.DataFrame,
     target_column : str
         Target column name. Target can be binary or continuous.
 
-    smoothing : float
+    smoothing : float (default: 1.0)
         Weight given to overall target mean against target mean by category.
         The value must be greater than or equal to 0
 
-    ignore_unseen : bool
+    ignore_unseen : bool (default: True)
         If True, unseen values will be encoded as nan
         If False, these will be replaced by target mean.
 


### PR DESCRIPTION
### Status
**READY**

### Description of the changes proposed in the pull request
- Documentation of `fklearn.training.transformation.target_categorizer` was missing default values for its arguments.
- API index (https://fklearn.readthedocs.io/en/latest/api.html#transformation-fklearn-training-transformation) is missing `target_categorizer`
