### PR TITLE
Add ecdf mapping to learner logs

### DIFF
--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -186,12 +186,16 @@ def ecdfer(df: pd.DataFrame,
 
     ecdf = ed.ECDF(values)
 
+    labels = ecdf.x
+    function_image = map(lambda image: base + sign * max_range * image, ecdf.y)
+
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
         return new_df.assign(**{ecdf_column: (base + sign * max_range * ecdf(new_df[prediction_column]))})
 
     p.__doc__ = learner_pred_fn_docstring("ecdefer")
 
     log = {'ecdfer': {
+        'map': dict(zip(labels, function_image)),
         'nobs': len(values),
         'prediction_column': prediction_column,
         'ascending': ascending,

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -192,7 +192,7 @@ def ecdfer(df: pd.DataFrame,
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
         return new_df.assign(**{ecdf_column: (base + sign * max_range * ecdf(new_df[prediction_column]))})
 
-    p.__doc__ = learner_pred_fn_docstring("ecdefer")
+    p.__doc__ = learner_pred_fn_docstring("ecdfer")
 
     log = {'ecdfer': {
         'map': dict(zip(labels, function_image)),

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -150,7 +150,8 @@ def ecdfer(df: pd.DataFrame,
            ascending: bool = True,
            prediction_column: str = "prediction",
            ecdf_column: str = "prediction_ecdf",
-           max_range: int = 1000) -> LearnerReturnType:
+           max_range: int = 1000,
+           store_mapping: bool = False) -> LearnerReturnType:
     """
     Learns an Empirical Cumulative Distribution Function from the specified column
     in the input DataFrame. It is usually used in the prediction column to convert
@@ -173,6 +174,9 @@ def ecdfer(df: pd.DataFrame,
     max_range : int
         The maximum value for the ECDF. It will go will go
          from 0 to max_range.
+
+    store_mapping : bool (default: False)
+        Whether to store the ecdf label -> value dictionary in the log.
     """
 
     if ascending:
@@ -195,11 +199,13 @@ def ecdfer(df: pd.DataFrame,
     p.__doc__ = learner_pred_fn_docstring("ecdfer")
 
     log = {'ecdfer': {
-        'map': dict(zip(labels, function_image)),
         'nobs': len(values),
         'prediction_column': prediction_column,
         'ascending': ascending,
         'transformed_column': [ecdf_column]}}
+
+    if store_mapping:
+        log['ecdfer']['map'] = dict(zip(labels, function_image))
 
     return p, p(df), log
 

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -528,6 +528,7 @@ def test_ecdfer():
     actual_df = pred_fn(input_df)
 
     assert_almost_equal(expected_df[ecdf_column].values, actual_df[ecdf_column].values, decimal=5)
+    assert log["ecdfer"].get("map") is not None
 
     ascending = False
     pred_fn, data, log = ecdfer(fit_df, ascending, prediction_column, ecdf_column, max_range)
@@ -537,6 +538,7 @@ def test_ecdfer():
     })
     actual_df = pred_fn(input_df)
     assert_almost_equal(expected_df[ecdf_column].values, actual_df[ecdf_column].values, decimal=5)
+    assert log["ecdfer"].get("map") is not None
 
 
 def test_discrete_ecdfer():

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -524,14 +524,14 @@ def test_ecdfer():
     ecdf_column = "prediction_ecdf"
     max_range = 1000
 
-    pred_fn, data, log = ecdfer(fit_df, ascending, prediction_column, ecdf_column, max_range)
+    pred_fn, data, log = ecdfer(fit_df, ascending, prediction_column, ecdf_column, max_range, store_mapping=False)
     actual_df = pred_fn(input_df)
 
     assert_almost_equal(expected_df[ecdf_column].values, actual_df[ecdf_column].values, decimal=5)
-    assert log["ecdfer"].get("map") is not None
+    assert log["ecdfer"].get("map") is None
 
     ascending = False
-    pred_fn, data, log = ecdfer(fit_df, ascending, prediction_column, ecdf_column, max_range)
+    pred_fn, data, log = ecdfer(fit_df, ascending, prediction_column, ecdf_column, max_range, store_mapping=True)
 
     expected_df = pd.DataFrame({
         "prediction_ecdf": [800.0, 800.0, 700.0, 700.0, 500.0, 300.0, 300.0, 200.0, 100.0, 0.0, 0.0]


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Tests added and passed

### Background context
In some cases we need to be able to have access to the learned ecdf map.

### Description of the changes proposed in the pull request
Adding the learned ecdf map to the learner log, as well as fixing the its prediction function log name.