### PR TITLE
Allow users to install all compatible numba vers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pandas>=0.24.1,<0.25
 scikit-learn>=0.21.2,<0.22.0
 statsmodels>=0.9.0,<1
 toolz>=0.9.0,<1
-numba==0.48.0
+numba>=0.48.0,<0.50


### PR DESCRIPTION
### Status
**READY**

### Background context
With a `==` requirement definition we were to restrictive, and this could class with other libraries requirements

### Description of the changes proposed in the pull request
Allow users to install any of the compatible numba's versions