### PR TITLE
Include min and max values in the extremeintervals on quantile biner.

### DIFF
--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -643,9 +643,12 @@ def quantile_biner(df: pd.DataFrame,
     bin_getter = lambda col: pd.qcut(df[col], q, retbins=True)[1]
     bins = {column: bin_getter(column) for column in columns_to_bin}
 
+    def _fix_values(values, max):
+        return [1.0 if value == 0 else (value - 1.0 if value == max else value) for value in values]
+
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
         col_biner = lambda col: np.where(new_df[col].isnull(), nan, np.digitize(new_df[col], bins[col], right=right))
-        bined_columns = {col: col_biner(col) for col in columns_to_bin}
+        bined_columns = {col: _fix_values(col_biner(col), len(bins[col])) for col in columns_to_bin}
         return new_df.assign(**bined_columns)
 
     p.__doc__ = learner_pred_fn_docstring("quantile_biner")


### PR DESCRIPTION
### Status
**READY**

- [ ] Issue: closes #112

### Background context
quantile_biner would result in n+1 quantiles when the min or max values were equal to either the first or last quantile.

### Description of the changes proposed in the pull request
Change values categorized as the '0' quantile to 1 and values categorizes as 'n+1' (n being the wanted number of quantiles)
to n.
