### PR TITLE
Add decorator to value mapper

### DIFF
--- a/src/fklearn/preprocessing/schema.py
+++ b/src/fklearn/preprocessing/schema.py
@@ -117,8 +117,6 @@ def column_duplicatable(columns_to_bind: str) -> Callable:
                     columns_to_duplicate: Any = (kwargs[columns_to_bind] if columns_to_bind in
                                                  kwargs.keys() else
                                                  args[child_spec.args.index(columns_to_bind)])
-                    if isinstance(columns_to_duplicate, dict):
-                        columns_to_duplicate = list(columns_to_duplicate.keys())
                     mixin_kwargs['columns_to_duplicate'] = columns_to_duplicate
 
                 mixin_fn, mixin_df, mixin_log = mixin(df, **mixin_kwargs)

--- a/src/fklearn/preprocessing/schema.py
+++ b/src/fklearn/preprocessing/schema.py
@@ -117,6 +117,8 @@ def column_duplicatable(columns_to_bind: str) -> Callable:
                     columns_to_duplicate: Any = (kwargs[columns_to_bind] if columns_to_bind in
                                                  kwargs.keys() else
                                                  args[child_spec.args.index(columns_to_bind)])
+                    if isinstance(columns_to_duplicate, dict):
+                        columns_to_duplicate = list(columns_to_duplicate.keys())
                     mixin_kwargs['columns_to_duplicate'] = columns_to_duplicate
 
                 mixin_fn, mixin_df, mixin_log = mixin(df, **mixin_kwargs)

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -361,6 +361,7 @@ def apply_replacements(df: pd.DataFrame,
     return df.assign(**categ_columns)
 
 
+@column_duplicatable('value_maps')
 @curry
 @log_learner_time(learner_name="value_mapper")
 def value_mapper(df: pd.DataFrame,

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -173,6 +173,12 @@ def test_value_mapper():
     }
 
     pred_fn, data_ignore, log = value_mapper(input_df, value_maps)
+    pred_fn2, data_ignore2, log2 = value_mapper(input_df, value_maps, suffix="_suffix")
+    pred_fn3, data_ignore3, log3 = value_mapper(input_df, value_maps, prefix="prefix_")
+    pred_fn4, data_ignore4, log4 = value_mapper(input_df, value_maps,
+                                                columns_mapping={"feat1": "feat1_raw",
+                                                                 "feat2": "feat2_raw",
+                                                                 "feat3": "feat3_raw"})
     pred_fn, data_not_ignore, log = value_mapper(
         input_df, value_maps, ignore_unseen=False
     )
@@ -195,6 +201,18 @@ def test_value_mapper():
 
     assert expected_ignore.equals(data_ignore)
     assert expected_not_ignore.equals(data_not_ignore)
+
+    assert pd.concat(
+        [expected_ignore, input_df.copy().add_suffix("_suffix")], axis=1
+    ).equals(data_ignore2)
+
+    assert pd.concat(
+        [expected_ignore, input_df.copy().add_prefix("prefix_")], axis=1
+    ).equals(data_ignore3)
+
+    assert pd.concat(
+        [expected_ignore, input_df.copy().add_suffix("_raw")], axis=1
+    ).equals(data_ignore4)
 
 
 def test_truncate_categorical():


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
Value mapper transformation currently overwrites the values in a column. Update the `column_duplicatable` decorator to allow storing both mapped and original values.