### PR TITLE
Pre generate api documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,6 @@ instance/
 
 # Sphinx documentation
 docs/build/
-docs/source/api
 
 # PyBuilder
 target/

--- a/docs/source/api/fklearn.causal.rst
+++ b/docs/source/api/fklearn.causal.rst
@@ -1,0 +1,37 @@
+fklearn.causal package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    fklearn.causal.validation
+
+Submodules
+----------
+
+fklearn.causal.debias module
+----------------------------
+
+.. automodule:: fklearn.causal.debias
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.causal.effects module
+-----------------------------
+
+.. automodule:: fklearn.causal.effects
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.causal
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.causal.validation.rst
+++ b/docs/source/api/fklearn.causal.validation.rst
@@ -1,0 +1,38 @@
+fklearn.causal.validation package
+=================================
+
+Submodules
+----------
+
+fklearn.causal.validation.auc module
+------------------------------------
+
+.. automodule:: fklearn.causal.validation.auc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.causal.validation.cate module
+-------------------------------------
+
+.. automodule:: fklearn.causal.validation.cate
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.causal.validation.curves module
+---------------------------------------
+
+.. automodule:: fklearn.causal.validation.curves
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.causal.validation
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.data.rst
+++ b/docs/source/api/fklearn.data.rst
@@ -1,0 +1,22 @@
+fklearn.data package
+====================
+
+Submodules
+----------
+
+fklearn.data.datasets module
+----------------------------
+
+.. automodule:: fklearn.data.datasets
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.data
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.metrics.rst
+++ b/docs/source/api/fklearn.metrics.rst
@@ -1,0 +1,22 @@
+fklearn.metrics package
+=======================
+
+Submodules
+----------
+
+fklearn.metrics.pd\_extractors module
+-------------------------------------
+
+.. automodule:: fklearn.metrics.pd_extractors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.metrics
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.preprocessing.rst
+++ b/docs/source/api/fklearn.preprocessing.rst
@@ -1,0 +1,38 @@
+fklearn.preprocessing package
+=============================
+
+Submodules
+----------
+
+fklearn.preprocessing.rebalancing module
+----------------------------------------
+
+.. automodule:: fklearn.preprocessing.rebalancing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.preprocessing.schema module
+-----------------------------------
+
+.. automodule:: fklearn.preprocessing.schema
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.preprocessing.splitting module
+--------------------------------------
+
+.. automodule:: fklearn.preprocessing.splitting
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.preprocessing
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.rst
+++ b/docs/source/api/fklearn.rst
@@ -1,0 +1,44 @@
+fklearn package
+===============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    fklearn.causal
+    fklearn.data
+    fklearn.metrics
+    fklearn.preprocessing
+    fklearn.training
+    fklearn.tuning
+    fklearn.types
+    fklearn.validation
+
+Submodules
+----------
+
+fklearn.common\_docstrings module
+---------------------------------
+
+.. automodule:: fklearn.common_docstrings
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.version module
+----------------------
+
+.. automodule:: fklearn.version
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.training.rst
+++ b/docs/source/api/fklearn.training.rst
@@ -1,0 +1,86 @@
+fklearn.training package
+========================
+
+Submodules
+----------
+
+fklearn.training.calibration module
+-----------------------------------
+
+.. automodule:: fklearn.training.calibration
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.classification module
+--------------------------------------
+
+.. automodule:: fklearn.training.classification
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.ensemble module
+--------------------------------
+
+.. automodule:: fklearn.training.ensemble
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.imputation module
+----------------------------------
+
+.. automodule:: fklearn.training.imputation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.pipeline module
+--------------------------------
+
+.. automodule:: fklearn.training.pipeline
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.regression module
+----------------------------------
+
+.. automodule:: fklearn.training.regression
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.transformation module
+--------------------------------------
+
+.. automodule:: fklearn.training.transformation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.unsupervised module
+------------------------------------
+
+.. automodule:: fklearn.training.unsupervised
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.training.utils module
+-----------------------------
+
+.. automodule:: fklearn.training.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.training
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.tuning.rst
+++ b/docs/source/api/fklearn.tuning.rst
@@ -1,0 +1,62 @@
+fklearn.tuning package
+======================
+
+Submodules
+----------
+
+fklearn.tuning.model\_agnostic\_fc module
+-----------------------------------------
+
+.. automodule:: fklearn.tuning.model_agnostic_fc
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.tuning.parameter\_tuners module
+---------------------------------------
+
+.. automodule:: fklearn.tuning.parameter_tuners
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.tuning.samplers module
+------------------------------
+
+.. automodule:: fklearn.tuning.samplers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.tuning.selectors module
+-------------------------------
+
+.. automodule:: fklearn.tuning.selectors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.tuning.stoppers module
+------------------------------
+
+.. automodule:: fklearn.tuning.stoppers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.tuning.utils module
+---------------------------
+
+.. automodule:: fklearn.tuning.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.tuning
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.types.rst
+++ b/docs/source/api/fklearn.types.rst
@@ -1,0 +1,22 @@
+fklearn.types package
+=====================
+
+Submodules
+----------
+
+fklearn.types.types module
+--------------------------
+
+.. automodule:: fklearn.types.types
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.types
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/fklearn.validation.rst
+++ b/docs/source/api/fklearn.validation.rst
@@ -1,0 +1,46 @@
+fklearn.validation package
+==========================
+
+Submodules
+----------
+
+fklearn.validation.evaluators module
+------------------------------------
+
+.. automodule:: fklearn.validation.evaluators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.validation.perturbators module
+--------------------------------------
+
+.. automodule:: fklearn.validation.perturbators
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.validation.splitters module
+-----------------------------------
+
+.. automodule:: fklearn.validation.splitters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+fklearn.validation.validator module
+-----------------------------------
+
+.. automodule:: fklearn.validation.validator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: fklearn.validation
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,7 @@
+fklearn
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   fklearn

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -9,4 +9,4 @@ activate_venv
 
 venv/bin/python3 -m pip install -r docs/requirements.txt
 
-cd docs/ && make apidoc && make html
+cd docs/ && make html


### PR DESCRIPTION
### Status
**READY**

### Background context

Prior to this we removed all api related documentation from the repo, but seems that rtd needs it pre rendered, since the last doc release failed.

https://readthedocs.org/projects/fklearn/builds/15131392/

### Description of the changes proposed in the pull request

- Created api docs using `make apidoc` command