### PR TITLE
Use update_wrapper in column_duplicatable

### DIFF
--- a/tests/preprocessing/test_schema.py
+++ b/tests/preprocessing/test_schema.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+from fklearn.training.transformation import capper
 from fklearn.preprocessing.schema import feature_duplicator
 
 
@@ -45,3 +46,8 @@ def test_feature_duplicator():
             input_df.copy(),
             columns_mapping={'b': 'c'},
         )[1])
+
+
+def test_column_duplicatable_naming():
+    assert capper.__name__ == 'capper'
+    assert capper().__name__ == 'capper'


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Tests added and passed

### Background context
As of now, the decorator `column_duplicatable` isn't preserving some of the decorated metadata

### Description of the changes proposed in the pull request
- Persist the metadata through `column_duplicatable`
- Make `column_duplicatable` more robust with respect to currying
