### PR TITLE
Add causal curves summary

### DIFF
--- a/src/fklearn/causal/validation/curves.py
+++ b/src/fklearn/causal/validation/curves.py
@@ -220,7 +220,7 @@ def effect_curves(
      Creates a dataset summarizing the effect curves: cumulative effect, cumulative gain and
      relative cumulative gain. The dataset also contains two columns referencing the data
      used to compute the curves at each step: number of samples and fraction of samples used.
-     Moreover one column indicating the cumulative gain for a corresponding random model is 
+     Moreover one column indicating the cumulative gain for a corresponding random model is
      also included as a benchmark.
 
      Parameters
@@ -272,5 +272,7 @@ def effect_curves(
         samples_fraction=lambda x: x["samples_count"] / size,
         cumulative_gain_curve=lambda x: x["samples_fraction"] * x["cumulative_effect_curve"],
         random_model_cumulative_gain_curve=lambda x: x["samples_fraction"] * ate,
-        relative_cumulative_gain_curve=lambda x: x["samples_fraction"] * x["cumulative_effect_curve"] - x["random_model_cumulative_gain_curve"],
+        relative_cumulative_gain_curve=lambda x: (
+            x["samples_fraction"] * x["cumulative_effect_curve"] - x["random_model_cumulative_gain_curve"]
+        ),
     )

--- a/src/fklearn/causal/validation/curves.py
+++ b/src/fklearn/causal/validation/curves.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 import pandas as pd
 from toolz import curry, partial
@@ -202,3 +204,73 @@ def relative_cumulative_gain_curve(df: pd.DataFrame,
                                          min_rows=min_rows, steps=steps, effect_fn=effect_fn)
 
     return np.array([(effect - ate) * (rows / size) for rows, effect in zip(n_rows, cum_effect)])
+
+
+@curry
+def effect_curves(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> pd.DataFrame:
+    """
+     Creates a dataset summarizing the effect curves: cumulative effect, cumulative gain and
+     relative cumulative gain. The dataset also contains two columns referencing the data
+     used to compute the curves at each step: number of samples and fraction of samples used.
+     Moreover one column indicating the cumulative gain for a corresponding random model is 
+     also included as a benchmark.
+
+     Parameters
+     ----------
+     df : Pandas' DataFrame
+         A Pandas' DataFrame with target and prediction scores.
+
+     treatment : Strings
+         The name of the treatment column in `df`.
+
+     outcome : Strings
+         The name of the outcome column in `df`.
+
+     prediction : Strings
+         The name of the prediction column in `df`.
+
+     min_rows : Integer
+         Minimum number of observations needed to have a valid result.
+
+     steps : Integer
+         The number of cumulative steps to iterate when accumulating the effect
+
+     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+         of the outcome column.
+
+
+     Returns
+     ----------
+     summary curves dataset: pd.DataFrame
+         The dataset with the results for multiple validation causal curves according to the predictions ordering.
+    """
+
+    size: int = df.shape[0]
+    n_rows: List[int] = list(range(min_rows, size, size // steps)) + [size]
+
+    cum_effect: np.ndarray = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
+    ate: float = cum_effect[-1]
+
+    return pd.DataFrame({"samples_count": n_rows, "cumulative_effect_curve": cum_effect}).assign(
+        samples_fraction=lambda x: x["samples_count"] / size,
+        cumulative_gain_curve=lambda x: x["samples_fraction"] * x["cumulative_effect_curve"],
+        random_model_cumulative_gain_curve=lambda x: x["samples_fraction"] * ate,
+        relative_cumulative_gain_curve=lambda x: x["samples_fraction"] * x["cumulative_effect_curve"] - x["random_model_cumulative_gain_curve"],
+    )

--- a/tests/causal/validation/test_curves.py
+++ b/tests/causal/validation/test_curves.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pandas as pd
+from pandas.util.testing import assert_frame_equal
 
 from fklearn.causal.effects import linear_effect
 from fklearn.causal.validation.curves import (effect_by_segment, cumulative_effect_curve, cumulative_gain_curve,
-                                              relative_cumulative_gain_curve)
+                                              relative_cumulative_gain_curve, effect_curves)
 
 
 def test_effect_by_segment():
@@ -66,3 +67,26 @@ def test_relative_cumulative_gain_curve():
                                             steps=df.shape[0], effect_fn=linear_effect)
 
     np.testing.assert_allclose(expected, result, rtol=1e-07)
+
+
+def test_effect_curves():
+
+    df = pd.DataFrame(dict(
+        t=[1, 1, 1, 2, 2, 2, 3, 3, 3],
+        x=[1, 2, 3, 1, 2, 3, 1, 2, 3],
+        y=[1, 1, 1, 2, 3, 4, 3, 5, 7],
+    ))
+
+    expected = pd.DataFrame({
+        "samples_count": [3, 4, 5, 6, 7, 8, 9],
+        "samples_fraction": [0.3333333, 0.4444444, 0.5555555, 0.6666666, 0.7777777, 0.8888888, 1.],
+        "cumulative_effect_curve": [3., 3., 2.92857143, 2.5, 2.5, 2.46153846, 2.],
+        "cumulative_gain_curve": [1., 1.33333333, 1.62698413, 1.66666667, 1.94444444, 2.18803419, 2.],
+        "relative_cumulative_gain_curve": [0.33333333, 0.44444444, 0.51587302, 0.33333333, 0.38888889, 0.41025641, 0.],
+        "random_model_cumulative_gain_curve": [0.6666666, 0.8888888, 1.1111111, 1.3333333, 1.5555555, 1.7777777, 2.],
+    })
+
+    result = effect_curves(df, prediction="x", outcome="y", treatment="t", min_rows=3, steps=df.shape[0],
+                           effect_fn=linear_effect)
+
+    assert_frame_equal(result, expected, rtol=1e-07)

--- a/tests/causal/validation/test_curves.py
+++ b/tests/causal/validation/test_curves.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from pandas.util.testing import assert_frame_equal
 
 from fklearn.causal.effects import linear_effect
 from fklearn.causal.validation.curves import (effect_by_segment, cumulative_effect_curve, cumulative_gain_curve,
@@ -79,14 +78,14 @@ def test_effect_curves():
 
     expected = pd.DataFrame({
         "samples_count": [3, 4, 5, 6, 7, 8, 9],
-        "samples_fraction": [0.3333333, 0.4444444, 0.5555555, 0.6666666, 0.7777777, 0.8888888, 1.],
         "cumulative_effect_curve": [3., 3., 2.92857143, 2.5, 2.5, 2.46153846, 2.],
+        "samples_fraction": [0.3333333, 0.4444444, 0.5555555, 0.6666666, 0.7777777, 0.8888888, 1.],
         "cumulative_gain_curve": [1., 1.33333333, 1.62698413, 1.66666667, 1.94444444, 2.18803419, 2.],
-        "relative_cumulative_gain_curve": [0.33333333, 0.44444444, 0.51587302, 0.33333333, 0.38888889, 0.41025641, 0.],
         "random_model_cumulative_gain_curve": [0.6666666, 0.8888888, 1.1111111, 1.3333333, 1.5555555, 1.7777777, 2.],
+        "relative_cumulative_gain_curve": [0.33333333, 0.44444444, 0.51587302, 0.33333333, 0.38888889, 0.41025641, 0.],
     })
 
     result = effect_curves(df, prediction="x", outcome="y", treatment="t", min_rows=3, steps=df.shape[0],
                            effect_fn=linear_effect)
 
-    assert_frame_equal(result, expected, rtol=1e-07)
+    pd.testing.assert_frame_equal(result, expected, atol=1e-07)


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Description of the changes proposed in the pull request
Adding a function to summarize causal curves in a pandas dataframe.

Motivation:
* The current causal curve functions return a numpy array so only the y-axis of the curves is returned. Therefore, in order to plot the curves, it's necessary to rebuild an inner logic to construct the x-axis.
* We often need to plot all the causal curves to analyze and debug results. However, if we use the individual curve functions in each of those cases, we would have a meaningful redundancy in the computation since the core computation from the cumulative effect curve would be executed multiple times.