### PR TITLE
Add python minimal require to setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ devel_deps = test_deps + all_deps
 setup(name=MODULE_NAME,
       description="Functional machine learning",
       url='https://github.com/nubank/{:s}'.format(REPO_NAME),
+      python_requires='>=3.6.2',
       author="Nubank",
       package_dir={'': 'src'},
       packages=find_packages('src'),


### PR DESCRIPTION
## Context

There are [some indications](https://fklearn.readthedocs.io/en/latest/getting_started.html#installation) in the documentation about the minimal supported version, however, after looking at the problem reported on #189 it appears to be important to add a custom validation in the setup file to avoid problems when trying to install the library.

## Status

**READY**

Closes #189
