### PR TITLE
Replace CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 .common-values:
+  docker-image: &docker-image cimg/python:3.6
 
-  docker-image: &docker-image circleci/python:3.6
-
-  docker-image-python39: &docker-image-python39 circleci/python:3.9
+  docker-image-python39: &docker-image-python39 cimg/python:3.9
 
   working_directory: &working-directory ~/repo
 
@@ -80,7 +79,7 @@
         command: . scripts/run_tests.sh
 
 .test-steps-python39: &test-steps-python39
-  << : *test-steps
+  <<: *test-steps
   docker:
     - image: *docker-image-python39
 
@@ -183,7 +182,6 @@ jobs:
     <<: *release
   type-check:
     <<: *type-check
-
 
 workflows:
   version: 2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,6 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pip install wheel
-venv/bin/python3 setup.py sdist
-venv/bin/python3 setup.py bdist_wheel
+venv/bin/python -m pip install wheel
+venv/bin/python setup.py sdist
+venv/bin/python setup.py bdist_wheel

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -7,6 +7,6 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pip install -r docs/requirements.txt
+venv/bin/python -m pip install -r docs/requirements.txt
 
 cd docs/ && make html

--- a/scripts/create_venv.sh
+++ b/scripts/create_venv.sh
@@ -9,5 +9,5 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pip install -q --upgrade setuptools
-venv/bin/python3 -m pip install -q --upgrade pip
+venv/bin/python -m pip install -q --upgrade setuptools
+venv/bin/python -m pip install -q --upgrade pip

--- a/scripts/create_venv.sh
+++ b/scripts/create_venv.sh
@@ -5,7 +5,7 @@ set -e
 cur_dir=$(dirname ${BASH_SOURCE[0]})
 source $cur_dir/helpers.sh
 
-/usr/local/bin/python3 -m venv venv
+/usr/bin/env python3 -m venv venv
 
 activate_venv
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -8,5 +8,5 @@ activate_venv() {
 
 install_package() {
   activate_venv
-  venv/bin/python3 -m pip install -e .$1
+  venv/bin/python -m pip install -e .$1
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -7,8 +7,8 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pip install -q flake8==3.8.4
-venv/bin/python3 -m flake8 \
+venv/bin/python -m pip install -q flake8==3.8.4
+venv/bin/python -m flake8 \
   --ignore=E731,W503 \
   --filename=*.py \
   --exclude=__init__.py \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,5 +7,5 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pip install -q twine
+venv/bin/python -m pip install -q twine
 twine upload $1/*

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,6 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m pytest --cov=fklearn tests/
+venv/bin/python -m pytest --cov=fklearn tests/
 
 codecov

--- a/scripts/run_type_check.sh
+++ b/scripts/run_type_check.sh
@@ -7,4 +7,4 @@ source $cur_dir/helpers.sh
 
 activate_venv
 
-venv/bin/python3 -m mypy src tests --config mypy.ini
+venv/bin/python -m mypy src tests --config mypy.ini


### PR DESCRIPTION
## Context

When I was running one of the pipelines, I saw this deprecation message:
![Captura de Pantalla 2022-03-11 a la(s) 17 53 27](https://user-images.githubusercontent.com/14081477/157993057-80c77e55-31cf-4ce2-b9f5-697dc1e7b815.png)

This PR is to update the old container images used in our pipelines following [this doc](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)
 
### Status

**IN DEVELOPMENT**

I'm still figuring out why with the local `circleci` tool, everything works, but in the pipeline it fails.