### PR TITLE
Optionally returning training scores in the validator functions

### DIFF
--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -21,7 +21,7 @@ def validator_iteration(data: pd.DataFrame,
                         train_fn: LearnerFnType,
                         eval_fn: EvalFnType,
                         predict_oof: bool = False,
-                        return_train_score : bool = False,
+                        return_train_score: bool = False,
                         verbose: bool = False) -> LogType:
     """
     Perform an iteration of train test split, training and evaluation.

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -21,6 +21,7 @@ def validator_iteration(data: pd.DataFrame,
                         train_fn: LearnerFnType,
                         eval_fn: EvalFnType,
                         predict_oof: bool = False,
+                        return_train_score : bool = False,
                         verbose: bool = False) -> LogType:
     """
     Perform an iteration of train test split, training and evaluation.
@@ -51,6 +52,9 @@ def validator_iteration(data: pd.DataFrame,
     predict_oof : bool
         Whether to return out of fold predictions on the logs
 
+    return_train_score : bool
+        Whether to include train scores
+
     Returns
     ----------
     A log-like dictionary evaluations.
@@ -63,6 +67,8 @@ def validator_iteration(data: pd.DataFrame,
     warnings.warn(empty_set_warn) if train_data.shape[0] == 0 else None  # type: ignore
 
     predict_fn, train_out, train_log = train_fn(train_data)
+    if return_train_score:
+        train_log = assoc(train_log, "eval_results", eval_fn(train_out))
 
     eval_results = []
     oof_predictions = []

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -140,7 +140,7 @@ def validator(train_data: pd.DataFrame,
 
     return_all_train_logs : bool
         Whether to return the train logs corresponding to all the splits or to return
-        only the train log corresponding to the first split
+        only the train log corresponding to the first split (default behavior = only first split)
 
     verbose: bool
         Whether to show more information about the cross validation or not
@@ -177,7 +177,7 @@ def validator(train_data: pd.DataFrame,
 
     train_logs, validator_logs = zip(*map(_join_split_log, zipped_logs))
     if return_all_train_logs:
-        train_logs = {"train_log": [log['train_log'] for log in train_logs]}
+        train_logs = {"train_log": [log["train_log"] for log in train_logs]}
     else:
         train_logs = first(train_logs)
 

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -53,7 +53,7 @@ def validator_iteration(data: pd.DataFrame,
         Whether to return out of fold predictions on the logs
 
     return_eval_fn_on_train : bool
-        Whether to apply eval_fn to the training set and return the evaluation logs in the train log
+        Whether to apply eval_fn to the training set and return the resulting logs in the train log
 
     Returns
     ----------
@@ -136,7 +136,7 @@ def validator(train_data: pd.DataFrame,
         Whether to return out of fold predictions on the logs
 
     return_eval_fn_on_train : bool
-        Whether to apply eval_fn to the training sets and return the evaluation logs in the train logs
+        Whether to apply eval_fn to the training set of each split and return the resulting logs in the train logs
 
     return_all_train_logs : bool
         Whether to return the train logs corresponding to all the splits or to return
@@ -244,7 +244,7 @@ def parallel_validator(train_data: pd.DataFrame,
         Whether to return out of fold predictions on the logs
 
     return_eval_fn_on_train : bool
-        Whether to apply eval_fn to the training sets and return the evaluation logs in the train logs
+        Whether to apply eval_fn to the training set of each split and return the resulting logs in the train logs
 
     verbose: bool
         Whether to show more information about the cross validation or not

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -184,9 +184,11 @@ def parallel_validator_iteration(train_data: pd.DataFrame,
                                  train_fn: LearnerFnType,
                                  eval_fn: EvalFnType,
                                  predict_oof: bool,
+                                 return_train_score: bool = False,
                                  verbose: bool = False) -> LogType:
     (fold_num, (train_index, test_indexes)) = fold
-    return validator_iteration(train_data, train_index, test_indexes, fold_num, train_fn, eval_fn, predict_oof, verbose)
+    return validator_iteration(train_data, train_index, test_indexes, fold_num, train_fn, eval_fn, predict_oof,
+                               return_train_score, verbose)
 
 
 @curry
@@ -196,6 +198,7 @@ def parallel_validator(train_data: pd.DataFrame,
                        eval_fn: EvalFnType,
                        n_jobs: int = 1,
                        predict_oof: bool = False,
+                       return_train_score: bool = False,
                        verbose: bool = False) -> ValidatorReturnType:
     """
     Splits the training data into folds given by the split function and
@@ -228,6 +231,9 @@ def parallel_validator(train_data: pd.DataFrame,
     predict_oof : bool
         Whether to return out of fold predictions on the logs
 
+    return_train_score : bool
+        Whether to include train scores
+
     verbose: bool
         Whether to show more information about the cross validation or not
 
@@ -238,7 +244,8 @@ def parallel_validator(train_data: pd.DataFrame,
     folds, logs = split_fn(train_data)
 
     result = Parallel(n_jobs=n_jobs, backend="threading")(
-        delayed(parallel_validator_iteration)(train_data, x, train_fn, eval_fn, predict_oof, verbose)
+        delayed(parallel_validator_iteration)(train_data, x, train_fn, eval_fn, predict_oof, return_train_score,
+                                              verbose)
         for x in enumerate(folds))
     gc.collect()
 

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -21,7 +21,7 @@ def validator_iteration(data: pd.DataFrame,
                         train_fn: LearnerFnType,
                         eval_fn: EvalFnType,
                         predict_oof: bool = False,
-                        return_eval_fn_on_train: bool = False,
+                        return_eval_logs_on_train: bool = False,
                         verbose: bool = False) -> LogType:
     """
     Perform an iteration of train test split, training and evaluation.
@@ -52,7 +52,7 @@ def validator_iteration(data: pd.DataFrame,
     predict_oof : bool
         Whether to return out of fold predictions on the logs
 
-    return_eval_fn_on_train : bool
+    return_eval_logs_on_train : bool
         Whether to apply eval_fn to the training set and return the resulting logs in the train log
 
     Returns
@@ -67,7 +67,7 @@ def validator_iteration(data: pd.DataFrame,
     warnings.warn(empty_set_warn) if train_data.shape[0] == 0 else None  # type: ignore
 
     predict_fn, train_out, train_log = train_fn(train_data)
-    if return_eval_fn_on_train:
+    if return_eval_logs_on_train:
         train_log = assoc(train_log, "eval_results", eval_fn(train_out))
 
     eval_results = []
@@ -96,7 +96,7 @@ def validator(train_data: pd.DataFrame,
               perturb_fn_train: PerturbFnType = identity,
               perturb_fn_test: PerturbFnType = identity,
               predict_oof: bool = False,
-              return_eval_fn_on_train: bool = False,
+              return_eval_logs_on_train: bool = False,
               return_all_train_logs: bool = False,
               verbose: bool = False) -> ValidatorReturnType:
     """
@@ -135,7 +135,7 @@ def validator(train_data: pd.DataFrame,
     predict_oof : bool
         Whether to return out of fold predictions on the logs
 
-    return_eval_fn_on_train : bool
+    return_eval_logs_on_train : bool
         Whether to apply eval_fn to the training set of each split and return the resulting logs in the train logs
 
     return_all_train_logs : bool
@@ -158,7 +158,7 @@ def validator(train_data: pd.DataFrame,
     def fold_iter(fold: Tuple[int, Tuple[pd.Index, pd.Index]]) -> LogType:
         (fold_num, (train_index, test_indexes)) = fold
         return validator_iteration(train_data, train_index, test_indexes, fold_num,
-                                   train_fn, eval_fn, predict_oof, return_eval_fn_on_train, verbose)
+                                   train_fn, eval_fn, predict_oof, return_eval_logs_on_train, verbose)
 
     zipped_logs = pipe(folds,
                        enumerate,
@@ -196,11 +196,11 @@ def parallel_validator_iteration(train_data: pd.DataFrame,
                                  train_fn: LearnerFnType,
                                  eval_fn: EvalFnType,
                                  predict_oof: bool,
-                                 return_eval_fn_on_train: bool = False,
+                                 return_eval_logs_on_train: bool = False,
                                  verbose: bool = False) -> LogType:
     (fold_num, (train_index, test_indexes)) = fold
     return validator_iteration(train_data, train_index, test_indexes, fold_num, train_fn, eval_fn, predict_oof,
-                               return_eval_fn_on_train, verbose)
+                               return_eval_logs_on_train, verbose)
 
 
 @curry
@@ -210,7 +210,7 @@ def parallel_validator(train_data: pd.DataFrame,
                        eval_fn: EvalFnType,
                        n_jobs: int = 1,
                        predict_oof: bool = False,
-                       return_eval_fn_on_train: bool = False,
+                       return_eval_logs_on_train: bool = False,
                        verbose: bool = False) -> ValidatorReturnType:
     """
     Splits the training data into folds given by the split function and
@@ -243,7 +243,7 @@ def parallel_validator(train_data: pd.DataFrame,
     predict_oof : bool
         Whether to return out of fold predictions on the logs
 
-    return_eval_fn_on_train : bool
+    return_eval_logs_on_train : bool
         Whether to apply eval_fn to the training set of each split and return the resulting logs in the train logs
 
     verbose: bool
@@ -256,7 +256,7 @@ def parallel_validator(train_data: pd.DataFrame,
     folds, logs = split_fn(train_data)
 
     result = Parallel(n_jobs=n_jobs, backend="threading")(
-        delayed(parallel_validator_iteration)(train_data, x, train_fn, eval_fn, predict_oof, return_eval_fn_on_train,
+        delayed(parallel_validator_iteration)(train_data, x, train_fn, eval_fn, predict_oof, return_eval_logs_on_train,
                                               verbose)
         for x in enumerate(folds))
     gc.collect()

--- a/tests/validation/test_validator.py
+++ b/tests/validation/test_validator.py
@@ -54,6 +54,10 @@ def test_validator_iteration():
     assert result['train_log']['xgb_classification_learner']['features'] == ['f1']
     assert result['eval_results'][0]['some_score'] == 1.2
 
+    # test return_train_score=True
+    result = validator_iteration(data, train_index, test_indexes, 1, train_fn, eval_fn, False, True)
+    assert result['train_log']['eval_results']['some_score'] == 1.2
+
     # test empty dataset warning
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")

--- a/tests/validation/test_validator.py
+++ b/tests/validation/test_validator.py
@@ -54,7 +54,7 @@ def test_validator_iteration():
     assert result['train_log']['xgb_classification_learner']['features'] == ['f1']
     assert result['eval_results'][0]['some_score'] == 1.2
 
-    # test return_train_score=True
+    # test return_eval_fn_on_train=True
     result = validator_iteration(data, train_index, test_indexes, 1, train_fn, eval_fn, False, True)
     assert result['train_log']['eval_results']['some_score'] == 1.2
 


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
Computing training scores (metrics evaluated on the training set) can be useful to assess underfitting/overfitting and guide model selection (in e.g. the context of hyperparameter tuning). Sci-kit learn validation and hyperparameter exploration functions (such as `sklearn.model_selection` `cross_validate`, `GridSearchCV` and `RandomizedSearchCV`) provide the option of returning the training scores. This is implemented using the boolean optional parameter `return_train_score` which is False by default, meaning no training scores are returned under the default behavior. From scikit-learn documentation on this parameter: 

`return_train_score` bool, default=False
Whether to include train scores. Computing training scores is used to get insights on how different parameter settings impact the overfitting/underfitting trade-off. However computing the scores on the training set can be computationally expensive and is not strictly required to select the parameters that yield the best generalization performance.

### Description of the changes proposed in the pull request
In this PR I aim to replicate this behavior for the `validator_iteration`, `validator` and `parallel_validator` functions in fklearn/validation/validator.py file. 

In the `validator_iteration` function (this one currently trains on train and evaluates on test without evaluating on train) I added the boolean optional parameter `return_train_score` which is False by default, preserving current functionality if not used. 
- If `return_train_score=False` (default) the training metrics are not computed and the returned `logs` are exactly the same as before.
- If `return_train_score=True`, the `eval_fn` is applied also on the `train_data` and the results can be found in the returned `logs` (in `logs['train_log']['eval_results']`). This involved adding two lines of code (an `if` and the evaluation)

In the `parallel_validator_iteration` function the only changes are adding the new `return_train_score` parameter (optional, defaults to False preserving current functionality) and passing it to the `validator_iteration` function.

In the `parallel_validator` function (this one performs the train-evaluation sequence on multiple fold/splits in parallel) the only proposed changes involve adding the new `return_train_score` parameter (optional, defaults to False preserving current functionality) and passing it to the `parallel_validator_iteration` function.

In the `validator` function (this one performs the train-evaluation sequence on multiple fold/splits sequentially) the proposed changes involve adding the new `return_train_score` parameter (optional, defaults to False preserving current functionality) and passing it to the `validator_iteration` function. Additionally, this one current functionality returns only the train log corresponding to the first split (as opposed to `parallel_validator` which was already returning all). Thus, I added another `return_all_train_logs` parameter (optional, defaults to False preserving current functionality). If True returns all logs, if False preserves current functionality.

### Where should the reviewer start?
All changes so far are in the fklearn/validation/validator.py file