### PR TITLE
Add lgbm categorical features support

### DIFF
--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -502,6 +502,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
                                 learning_rate: float = 0.1,
                                 num_estimators: int = 100,
                                 extra_params: LogType = None,
+                                categorical_features: List[str] = "auto",
                                 prediction_column: str = "prediction",
                                 weight_column: str = None,
                                 encode_extra_cols: bool = True) -> LearnerReturnType:
@@ -549,6 +550,11 @@ def lgbm_classification_learner(df: pd.DataFrame,
         https://github.com/Microsoft/LightGBM/blob/master/docs/Parameters.rst
         If not passed, the default will be used.
 
+    categorical_features : list of str, or 'auto', optional (default="auto")
+        A list of column names that should be treated as categorical features.
+        See the categorical_feature hyper-parameter in:
+        https://github.com/Microsoft/LightGBM/blob/master/docs/Parameters.rst
+
     prediction_column : str
         The name of the column with the predictions from the model.
 
@@ -570,7 +576,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
     features = features if not encode_extra_cols else expand_features_encoded(df, features)
 
     dtrain = lgbm.Dataset(df[features].values, label=df[target], feature_name=list(map(str, features)), weight=weights,
-                          silent=True)
+                          silent=True, categorical_feature=categorical_features)
 
     bst = lgbm.train(params, dtrain, num_estimators)
 

--- a/tests/training/test_classification.py
+++ b/tests/training/test_classification.py
@@ -431,6 +431,7 @@ def test_lgbm_classification_learner():
                                                  learning_rate=0.1,
                                                  num_estimators=20,
                                                  extra_params={"max_depth": 4, "seed": 42},
+                                                 categorical_features=["x2"],
                                                  prediction_column="prediction",
                                                  weight_column="w")
 


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [ ] Documentation
- [ ] Tests added and passed
- [ ] Issue: closes #194

### Background context

Older versions of LigthGBM used to allow passing `categorical_feature`through the argument `param`, but recent versions raise the following warning:

```
UserWarning: categorical_feature keyword has been found in `params` and will be ignored.
Please use categorical_feature argument of the Dataset constructor to pass this parameter.
  .format(key))
```

It is dubious (for me) if the warning is misleading and the option still works. [A contributor at lightgbm said that the correct way to pass them is through the Dataset object](https://github.com/microsoft/LightGBM/issues/1408#issuecomment-530096617).

### Description of the changes proposed in the pull request
Adds a new option `categorical_features` to `lgbm_classification_learner`. It allows a list of column names that should be treated as categorical features. Further instructions are found in https://github.com/Microsoft/LightGBM/blob/master/docs/Parameters.rst

### Remaining problems or questions
_(write the remaining problems or questions that this PR does not solve)_
