### PR TITLE
Added elasticnet_regression_learner

### DIFF
--- a/tests/training/test_regression.py
+++ b/tests/training/test_regression.py
@@ -8,6 +8,7 @@ from fklearn.training.regression import \
     xgb_regression_learner, lgbm_regression_learner, catboost_regressor_learner, \
     custom_supervised_model_learner, elasticnet_regression_learner
 
+
 def test_elasticnet_regression_learner():
     df_train = pd.DataFrame({
         'id': ["id1", "id2", "id3", "id4"],
@@ -42,6 +43,7 @@ def test_elasticnet_regression_learner():
     assert Counter(expected_col_test) == Counter(pred_test.columns.tolist())
     assert (pred_test.columns == pred_train.columns).all()
     assert "prediction" in pred_test.columns
+
 
 def test_linear_regression_learner():
     df_train = pd.DataFrame({

--- a/tests/training/test_regression.py
+++ b/tests/training/test_regression.py
@@ -6,8 +6,42 @@ import pandas as pd
 from fklearn.training.regression import \
     linear_regression_learner, gp_regression_learner, \
     xgb_regression_learner, lgbm_regression_learner, catboost_regressor_learner, \
-    custom_supervised_model_learner
+    custom_supervised_model_learner, elasticnet_regression_learner
 
+def test_elasticnet_regression_learner():
+    df_train = pd.DataFrame({
+        'id': ["id1", "id2", "id3", "id4"],
+        'x1': [10.0, 13.0, 10.0, 13.0],
+        "x2": [0, 1, 1, 0],
+        "w": [2, 1, 2, 0.5],
+        'y': [2.3, 4.0, 100.0, -3.9]
+    })
+
+    df_test = pd.DataFrame({
+        'id': ["id4", "id4", "id5", "id6"],
+        'x1': [12.0, 1000.0, -4.0, 0.0],
+        "x2": [1, 1, 0, 1],
+        "w": [1, 2, 0, 0.5],
+        'y': [1.3, -4.0, 0.0, 49]
+    })
+
+    learner = elasticnet_regression_learner(features=["x1", "x2"],
+                                            target="y",
+                                            params=None,
+                                            prediction_column="prediction",
+                                            weight_column="w")
+
+    predict_fn, pred_train, log = learner(df_train)
+
+    pred_test = predict_fn(df_test)
+
+    expected_col_train = df_train.columns.tolist() + ["prediction"]
+    expected_col_test = df_test.columns.tolist() + ["prediction"]
+
+    assert Counter(expected_col_train) == Counter(pred_train.columns.tolist())
+    assert Counter(expected_col_test) == Counter(pred_test.columns.tolist())
+    assert (pred_test.columns == pred_train.columns).all()
+    assert "prediction" in pred_test.columns
 
 def test_linear_regression_learner():
     df_train = pd.DataFrame({


### PR DESCRIPTION
Added elasticnet_regression_learner and its tests, and fixed typo in linear_regression_learner docstring

### Instructions
- Follow the instructions in [README.md](../blob/master/README.md)
- Delete everything between parenthesis _(...)_
- Remove the sections that are not relevant

### Status
**READY**

- READY: development over and everything ready for merging

### Todo list
- [x] Documentation
- [x] Tests added and passed
- [ ] Issue: closes #xxxx  _(write the number of the GitHub issues that this PR resolves)_

### Background context
Added elasticnet regression in order to productionize models that are being created in the Growth BU that makes use of Lasso regression.

### Description of the changes proposed in the pull request
Created the `elasticnet_regression_learner` with its respective test, also fixed an error in the docstring of the linear regression.

### Related PRs
No related PRs

### Where should the reviewer start?
The reviewer should start evaluating the function `elasticnet_regression_learner` at [regressors' file](../blob/master/src/fklearn/training/regression.py)

After this, should review the test created `test_elasticnet_regression_learner` at [regressors' test file](../blob/master/src/fklearn/tests/training/test_regression.py)

### Remaining problems or questions
There are no remaining questions or problems
