### PR TITLE
Vectorize apply_replacement

### DIFF
--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -354,7 +354,7 @@ def apply_replacements(df: pd.DataFrame,
         Default value to replace when original value is not present in the `vec` dict for the feature
 
     """
-    def column_categorizer(col: str):
+    def column_categorizer(col: str) -> np.ndarray:
         replaced = df[col].map(vec[col])
         unseen = df[col].notnull() & replaced.isnull()
         replaced[unseen] = replace_unseen

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -354,11 +354,8 @@ def apply_replacements(df: pd.DataFrame,
         Default value to replace when original value is not present in the `vec` dict for the feature
 
     """
-    def column_categorizer(col: str) -> np.ndarray:
-        replaced = df[col].map(vec[col])
-        unseen = df[col].notnull() & replaced.isnull()
-        replaced[unseen] = replace_unseen
-        return replaced
+    def column_categorizer(col: str) -> pd.Series:
+        return df[col].map(lambda x: vec[col].get(x, replace_unseen), na_action='ignore')
 
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -355,11 +355,10 @@ def apply_replacements(df: pd.DataFrame,
 
     """
     def column_categorizer(col: str):
-        return np.select(
-            [df[col].isna() | (df[col].dtype == "float"), ~df[col].isin(vec[col].keys())],
-            [np.nan, replace_unseen],
-            df[col].replace(vec[col])
-        ).astype(np.array(list(vec[col].values())).dtype)
+        replaced = df[col].map(vec[col])
+        unseen = df[col].notnull() & replaced.isnull()
+        replaced[unseen] = replace_unseen
+        return replaced
 
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -359,7 +359,7 @@ def apply_replacements(df: pd.DataFrame,
             [df[col].isna() | (df[col].dtype == "float"), ~df[col].isin(vec[col].keys())],
             [np.nan, replace_unseen],
             df[col].replace(vec[col])
-    )
+        )
 
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -354,9 +354,13 @@ def apply_replacements(df: pd.DataFrame,
         Default value to replace when original value is not present in the `vec` dict for the feature
 
     """
-    column_categorizer = lambda col: df[col].apply(lambda x: (np.nan
-                                                              if isinstance(x, float) and np.isnan(x)
-                                                              else vec[col].get(x, replace_unseen)))
+    def column_categorizer(col: str):
+        return np.select(
+            [df[col].isna() | (df[col].dtype == "float"), ~df[col].isin(vec[col].keys())],
+            [np.nan, replace_unseen],
+            df[col].replace(vec[col])
+    )
+
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)
 

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -359,7 +359,7 @@ def apply_replacements(df: pd.DataFrame,
             [df[col].isna() | (df[col].dtype == "float"), ~df[col].isin(vec[col].keys())],
             [np.nan, replace_unseen],
             df[col].replace(vec[col])
-        )
+        ).astype(np.array(list(vec[col].values())).dtype)
 
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -426,7 +426,7 @@ def test_count_categorizer():
     expected_output_test = pd.DataFrame(
         {
             "feat1_num": [2, 20, 200, 2000],
-            "feat2_cat": [3, 1, 1, 1],  # replace unseen vars with constant (1)
+            "feat2_cat": [3.0, 1.0, 1.0, 1.0],  # replace unseen vars with constant (1)
             "feat3_cat": [nan, nan, 3, 3],
         }
     )

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -537,10 +537,10 @@ def test_label_categorizer():
         {
             "feat1_num": [2, 20, 200, 2000],
             "feat2_cat": [
-                0,
-                1,
-                1,
-                -99,
+                0.0,
+                1.0,
+                1.0,
+                -99.0,
             ],  # replace unseen vars with constant (1)
             "feat3_cat": [nan, nan, 0, 0],
         }

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -426,7 +426,7 @@ def test_count_categorizer():
     expected_output_test = pd.DataFrame(
         {
             "feat1_num": [2, 20, 200, 2000],
-            "feat2_cat": [3.0, 1.0, 1.0, 1.0],  # replace unseen vars with constant (1)
+            "feat2_cat": [3, 1, 1, 1],  # replace unseen vars with constant (1)
             "feat3_cat": [nan, nan, 3, 3],
         }
     )
@@ -537,10 +537,10 @@ def test_label_categorizer():
         {
             "feat1_num": [2, 20, 200, 2000],
             "feat2_cat": [
-                0.0,
-                1.0,
-                1.0,
-                -99.0,
+                0,
+                1,
+                1,
+                -99,
             ],  # replace unseen vars with constant (1)
             "feat3_cat": [nan, nan, 0, 0],
         }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
Pandas .apply is incredibly slow to run. Since this function is used in multiple learners, speeding it up should yield tremendous grains in performance. As a side note, **we should never introduce new call `.apply`**. They are a major source of headache 

### Description of the changes proposed in the pull request
Vectorize `apply_replacements `

