### PR TITLE
Bugfix for some cases where validator fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.1.1] - 2022-08-17
+- **Bug Fix**
+  - Fix validator behavior when receiving data containing gaps and a time based split function that could generate empty 
+    training and testing folds and then break. 
+    The argument `drop_empty_folds` can be set to `True` to drop invalid folds from validation and store them in the 
+    log.
+ 
 ## [2.1.0] - 2022-07-25
 - **Enhancement**
     - Add optional parameter `return_eval_logs_on_train` to the `validator` function,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [2.1.1] - 2022-08-17
-- **Bug Fix**
-  - Fix validator behavior when receiving data containing gaps and a time based split function that could generate empty 
-    training and testing folds and then break. 
-    The argument `drop_empty_folds` can be set to `True` to drop invalid folds from validation and store them in the 
-    log.
- 
 ## [2.1.0] - 2022-07-25
 - **Enhancement**
     - Add optional parameter `return_eval_logs_on_train` to the `validator` function,

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -178,8 +178,7 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple: typing.Tuple[zip[typing.Tuple[Any, Any]], typing.List[Any]]) -> \
-            typing.Tuple[zip[typing.Tuple[Any, Any]], typing.List[Any]]:
+    def clean_logs(log_tuple: typing.Tuple) -> (typing.Tuple, typing.List):
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -164,7 +164,7 @@ def validator(train_data: pd.DataFrame,
 
     def fold_iter(fold: Tuple[int, Tuple[pd.Index, pd.Index]]) -> LogType:
         (fold_num, (train_index, test_indexes)) = fold
-        
+
         test_contains_null_folds = max(map(lambda x: len(x) == 0, test_indexes))
         train_fold_is_null = len(train_index) == 0
 

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -104,9 +104,9 @@ def validator(train_data: pd.DataFrame,
               verbose: bool = False,
               drop_empty_folds: bool = False) -> ValidatorReturnType:
     """
-    Splits the training data into folds given by the split function and
-    performs a train-evaluation sequence on each fold by calling
-    ``validator_iteration``.
+    Splits the training data into folds given by the split function and performs a train-evaluation sequence on each
+    fold by calling ``validator_iteration`` given the evaluation function. The output is a log containing, for each
+    fold, its logs and evaluator results.
 
     Parameters
     ----------

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -1,11 +1,11 @@
 import gc
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Any
 import warnings
 import inspect
 
 from joblib import Parallel, delayed
 import pandas as pd
-from toolz import compose
+from toolz import compose, curry
 from toolz.curried import assoc, curry, dissoc, first, map, partial, pipe
 from toolz.functoolz import identity
 
@@ -177,7 +177,7 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple: Tuple[LogType, LogType]) -> Tuple[LogType, LogType]:
+    def clean_logs(log_tuple: Tuple[LogType, LogType]) -> tuple[zip[tuple[Any, Any]], list[Any]]:
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -1,17 +1,17 @@
 import gc
-from typing import Dict, Tuple, List, Any
-import warnings
 import inspect
+import warnings
+from typing import Dict, Tuple, List, Any
 
-from joblib import Parallel, delayed
 import pandas as pd
-from toolz import compose, curry
+from joblib import Parallel, delayed
+from toolz import compose
 from toolz.curried import assoc, curry, dissoc, first, map, partial, pipe
 from toolz.functoolz import identity
+from tqdm import tqdm
 
 from fklearn.types import EvalFnType, LearnerFnType, LogType
 from fklearn.types import SplitterFnType, ValidatorReturnType, PerturbFnType
-from tqdm import tqdm
 
 
 def validator_iteration(data: pd.DataFrame,

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -1,5 +1,6 @@
 import gc
 import inspect
+import typing
 import warnings
 from typing import Dict, Tuple, List, Any
 
@@ -177,7 +178,8 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple: Tuple[LogType, LogType]) -> tuple[zip[tuple[Any, Any]], list[Any]]:
+    def clean_logs(log_tuple: typing.Tuple[zip[typing.Tuple[Any, Any]], typing.List[Any]]) -> \
+            typing.Tuple[zip[typing.Tuple[Any, Any]], typing.List[Any]]:
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -1,6 +1,5 @@
 import gc
 import inspect
-import typing
 import warnings
 from typing import Dict, Tuple, List
 
@@ -178,7 +177,7 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple: typing.Tuple) -> (typing.Tuple, typing.List):
+    def clean_logs(log_tuple: Tuple) -> Tuple:
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -164,7 +164,11 @@ def validator(train_data: pd.DataFrame,
 
     def fold_iter(fold: Tuple[int, Tuple[pd.Index, pd.Index]]) -> LogType:
         (fold_num, (train_index, test_indexes)) = fold
-        if (len(train_index) <= 1 or len(test_indexes[0]) == 0) and drop_empty_folds:
+        
+        test_contains_null_folds = max(map(lambda x: len(x) == 0, test_indexes))
+        train_fold_is_null = len(train_index) == 0
+
+        if (train_fold_is_null or test_contains_null_folds) and drop_empty_folds:
             return {"empty_fold": True}
         else:
             iter_results = validator_iteration(train_data, train_index, test_indexes, fold_num,

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -177,7 +177,7 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple) -> Tuple:
+    def clean_logs(log_tuple: Tuple[LogType, LogType]) -> Tuple[LogType, LogType]:
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -177,7 +177,7 @@ def validator(train_data: pd.DataFrame,
                        map(fold_iter),
                        partial(zip, logs))
 
-    def clean_logs(log_tuple):
+    def clean_logs(log_tuple) -> Tuple:
         split_log_error = list()
 
         new_validator_logs = list()

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -55,6 +55,9 @@ def validator_iteration(data: pd.DataFrame,
     return_eval_logs_on_train : bool
         Whether to apply eval_fn to the training set and return the resulting logs in the train log
 
+    verbose : bool
+        Whether to print the starting status of the fold to be evaluated.
+
     Returns
     ----------
     A log-like dictionary evaluations.
@@ -98,7 +101,8 @@ def validator(train_data: pd.DataFrame,
               predict_oof: bool = False,
               return_eval_logs_on_train: bool = False,
               return_all_train_logs: bool = False,
-              verbose: bool = False) -> ValidatorReturnType:
+              verbose: bool = False,
+              drop_empty_folds: bool = False) -> ValidatorReturnType:
     """
     Splits the training data into folds given by the split function and
     performs a train-evaluation sequence on each fold by calling
@@ -142,8 +146,11 @@ def validator(train_data: pd.DataFrame,
         Whether to return the train logs corresponding to all the splits or to return
         only the train log corresponding to the first split (default behavior = only first split)
 
-    verbose: bool
+    verbose : bool
         Whether to show more information about the cross validation or not
+
+    drop_empty_folds : bool
+        Whether to drop empty folds from validation and allocate them into an error log
 
     Returns
     ----------
@@ -157,13 +164,35 @@ def validator(train_data: pd.DataFrame,
 
     def fold_iter(fold: Tuple[int, Tuple[pd.Index, pd.Index]]) -> LogType:
         (fold_num, (train_index, test_indexes)) = fold
-        return validator_iteration(train_data, train_index, test_indexes, fold_num,
-                                   train_fn, eval_fn, predict_oof, return_eval_logs_on_train, verbose)
+        if (len(train_index) <= 1 or len(test_indexes[0]) == 0) and drop_empty_folds:
+            return {"empty_fold": True}
+        else:
+            iter_results = validator_iteration(train_data, train_index, test_indexes, fold_num,
+                                               train_fn, eval_fn, predict_oof, return_eval_logs_on_train, verbose)
+
+        return assoc(iter_results, "empty_fold", False)
 
     zipped_logs = pipe(folds,
                        enumerate,
                        map(fold_iter),
                        partial(zip, logs))
+
+    def clean_logs(log_tuple):
+        split_log_error = list()
+
+        new_validator_logs = list()
+        new_split_log = list()
+        for split_log, validator_log in log_tuple:
+            if not validator_log["empty_fold"]:
+                new_validator_logs.append(dissoc(validator_log, "empty_fold"))
+                new_split_log.append(split_log)
+            else:
+                split_log_error.append(split_log)
+
+        return zip(new_split_log, new_validator_logs), split_log_error
+
+    if drop_empty_folds:
+        zipped_logs, zipped_error_logs = clean_logs(zipped_logs)
 
     def _join_split_log(log_tuple: Tuple[LogType, LogType]) -> Tuple[LogType, LogType]:
         train_log = {}
@@ -187,6 +216,9 @@ def validator(train_data: pd.DataFrame,
     if perturb_fn_test != identity:
         perturbator_log['perturbated_test'] = get_perturbed_columns(perturb_fn_test)
     train_logs = assoc(train_logs, "perturbator_log", perturbator_log)
+
+    if drop_empty_folds:
+        train_logs = assoc(train_logs, "fold_error_logs", zipped_error_logs)
 
     return assoc(train_logs, "validator_log", list(validator_logs))
 

--- a/src/fklearn/validation/validator.py
+++ b/src/fklearn/validation/validator.py
@@ -2,7 +2,7 @@ import gc
 import inspect
 import typing
 import warnings
-from typing import Dict, Tuple, List, Any
+from typing import Dict, Tuple, List
 
 import pandas as pd
 from joblib import Parallel, delayed

--- a/tests/validation/test_validator.py
+++ b/tests/validation/test_validator.py
@@ -6,7 +6,11 @@ from toolz.functoolz import identity
 
 from fklearn.training.classification import lgbm_classification_learner
 from fklearn.validation import splitters, evaluators
-from fklearn.validation.validator import validator_iteration, validator, parallel_validator
+from fklearn.validation.validator import (
+    validator_iteration,
+    validator,
+    parallel_validator,
+)
 from fklearn.validation.perturbators import perturbator, nullify
 import pytest
 import sklearn
@@ -17,37 +21,39 @@ def train_fn(df):
     def p(new_df):
         return new_df.assign(prediction=0)
 
-    log = {'xgb_classification_learner': {
-        'features': ['f1'],
-        'target': 'target',
-        'prediction_column': "prediction",
-        'package': "xgboost",
-        'package_version': "3",
-        'parameters': {"a": 3},
-        'feature_importance': {"f1": 1},
-        'running_time': "3 ms",
-        'training_samples': len(df)
-    }}
+    log = {
+        "xgb_classification_learner": {
+            "features": ["f1"],
+            "target": "target",
+            "prediction_column": "prediction",
+            "package": "xgboost",
+            "package_version": "3",
+            "parameters": {"a": 3},
+            "feature_importance": {"f1": 1},
+            "running_time": "3 ms",
+            "training_samples": len(df),
+        }
+    }
 
     return p, p(df), log
 
 
 def eval_fn(test_data):
-    return {'some_score': 1.2}
+    return {"some_score": 1.2}
 
 
 def split_fn(df):
-    return [([0, 1], [[2, 3], [2], [3]]),
-            ([2, 3], [[0, 1]])], [{"fold": 1}, {"fold": 2}]
+    return [([0, 1], [[2, 3], [2], [3]]), ([2, 3], [[0, 1]])], [
+        {"fold": 1},
+        {"fold": 2},
+    ]
 
 
 perturb_fn_train = identity
-perturb_fn_test = perturbator(cols=['rows'], corruption_fn=nullify(perc=0.25))
+perturb_fn_test = perturbator(cols=["rows"], corruption_fn=nullify(perc=0.25))
 
 
-data = pd.DataFrame({
-    'rows': ['row1', 'row2', 'row3', 'row4']
-})
+data = pd.DataFrame({"rows": ["row1", "row2", "row3", "row4"]})
 
 
 def test_validator_iteration():
@@ -56,13 +62,15 @@ def test_validator_iteration():
 
     result = validator_iteration(data, train_index, test_indexes, 1, train_fn, eval_fn)
 
-    assert result['fold_num'] == 1
-    assert result['train_log']['xgb_classification_learner']['features'] == ['f1']
-    assert result['eval_results'][0]['some_score'] == 1.2
+    assert result["fold_num"] == 1
+    assert result["train_log"]["xgb_classification_learner"]["features"] == ["f1"]
+    assert result["eval_results"][0]["some_score"] == 1.2
 
     # test return_eval_fn_on_train=True
-    result = validator_iteration(data, train_index, test_indexes, 1, train_fn, eval_fn, False, True)
-    assert result['train_log']['eval_results']['some_score'] == 1.2
+    result = validator_iteration(
+        data, train_index, test_indexes, 1, train_fn, eval_fn, False, True
+    )
+    assert result["train_log"]["eval_results"]["some_score"] == 1.2
 
     # test empty dataset warning
     with warnings.catch_warnings(record=True) as w:
@@ -74,105 +82,135 @@ def test_validator_iteration():
 
 def test_validator():
     model = lgbm_classification_learner(
-        target="target",
-        features=["feat1", "feat2"],
-        extra_params={"verbose": -1}
+        target="target", features=["feat1", "feat2"], extra_params={"verbose": -1}
     )
 
-    df_no_gap = pd.DataFrame({
-        "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
-        "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
-        "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
-        "date": [
-            datetime.strptime(d, "%Y-%m-%d") for d in ["2021-01-01", "2021-01-09", "2021-02-08",
-                                                       "2021-02-10", "2021-03-20", "2021-03-11",
-                                                       "2021-04-01", "2021-04-02", "2021-05-15",
-                                                       "2021-05-15", "2021-06-01", "2021-06-02",
-                                                       "2021-07-15", "2021-07-15"]
-        ]
-    })
+    df_no_gap = pd.DataFrame(
+        {
+            "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
+            "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
+            "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
+            "date": [
+                datetime.strptime(d, "%Y-%m-%d")
+                for d in [
+                    "2021-01-01",
+                    "2021-01-09",
+                    "2021-02-08",
+                    "2021-02-10",
+                    "2021-03-20",
+                    "2021-03-11",
+                    "2021-04-01",
+                    "2021-04-02",
+                    "2021-05-15",
+                    "2021-05-15",
+                    "2021-06-01",
+                    "2021-06-02",
+                    "2021-07-15",
+                    "2021-07-15",
+                ]
+            ],
+        }
+    )
 
     split_fn_no_gap = splitters.forward_stability_curve_time_splitter(
         training_time_start=df_no_gap["date"].min(),
         training_time_end=df_no_gap["date"].min() + timedelta(60),
         time_column="date",
         step=timedelta(30),
-        holdout_size=timedelta(30)
+        holdout_size=timedelta(30),
     )
 
     eval_fn_no_gap = evaluators.roc_auc_evaluator(
-        prediction_column="prediction",
-        target_column="target"
+        prediction_column="prediction", target_column="target"
     )
 
     perturb_fn_train_no_gap = identity
-    perturb_fn_test_no_gap = perturbator(cols=['feat1'], corruption_fn=nullify(perc=0.25))
+    perturb_fn_test_no_gap = perturbator(
+        cols=["feat1"], corruption_fn=nullify(perc=0.25)
+    )
 
-    result_no_gap = validator(df_no_gap, split_fn_no_gap, model, eval_fn_no_gap, perturb_fn_train_no_gap, perturb_fn_test_no_gap)
+    result_no_gap = validator(
+        df_no_gap,
+        split_fn_no_gap,
+        model,
+        eval_fn_no_gap,
+        perturb_fn_train_no_gap,
+        perturb_fn_test_no_gap,
+    )
 
     validator_log = result_no_gap["validator_log"]
 
     assert len(validator_log[1]) == 4
-    assert validator_log[0]['fold_num'] == 0
-    assert result_no_gap['train_log']['lgbm_classification_learner']['features'] == ['feat1', 'feat2']
+    assert validator_log[0]["fold_num"] == 0
+    assert result_no_gap["train_log"]["lgbm_classification_learner"]["features"] == [
+        "feat1",
+        "feat2",
+    ]
 
-    assert len(validator_log[0]['eval_results']) == 1
+    assert len(validator_log[0]["eval_results"]) == 1
 
-    assert validator_log[1]['fold_num'] == 1
-    assert len(validator_log[1]['eval_results']) == 1
+    assert validator_log[1]["fold_num"] == 1
+    assert len(validator_log[1]["eval_results"]) == 1
 
     perturbator_log = result_no_gap["perturbator_log"]
 
-    assert perturbator_log['perturbated_train'] == []
-    assert perturbator_log['perturbated_test'] == ['feat1']
+    assert perturbator_log["perturbated_train"] == []
+    assert perturbator_log["perturbated_test"] == ["feat1"]
 
 
 def test_validator_with_gap():
     model = lgbm_classification_learner(
-        target="target",
-        features=["feat1", "feat2"],
-        extra_params={"verbose": -1}
+        target="target", features=["feat1", "feat2"], extra_params={"verbose": -1}
     )
 
-    df_gap = pd.DataFrame({
-        "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
-        "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
-        "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
-        "date": [
-            datetime.strptime(d, "%Y-%m-%d") for d in ["2021-01-01", "2021-01-09", "2021-02-08",
-                                                       "2021-02-10", "2021-03-20", "2021-03-11",
-                                                       "2021-07-01", "2021-07-02", "2021-09-15",
-                                                       "2021-09-15", "2021-10-01", "2021-10-02",
-                                                       "2021-11-15", "2021-11-15"]
-        ]
-    })
+    df_gap = pd.DataFrame(
+        {
+            "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
+            "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
+            "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
+            "date": [
+                datetime.strptime(d, "%Y-%m-%d")
+                for d in [
+                    "2021-01-01",
+                    "2021-01-09",
+                    "2021-02-08",
+                    "2021-02-10",
+                    "2021-03-20",
+                    "2021-03-11",
+                    "2021-07-01",
+                    "2021-07-02",
+                    "2021-09-15",
+                    "2021-09-15",
+                    "2021-10-01",
+                    "2021-10-02",
+                    "2021-11-15",
+                    "2021-11-15",
+                ]
+            ],
+        }
+    )
 
     split_fn_gap = splitters.forward_stability_curve_time_splitter(
         training_time_start=df_gap["date"].min(),
         training_time_end=df_gap["date"].min() + timedelta(60),
         time_column="date",
         step=timedelta(30),
-        holdout_size=timedelta(30)
+        holdout_size=timedelta(30),
     )
 
     eval_fn_gap = evaluators.roc_auc_evaluator(
-        prediction_column="prediction",
-        target_column="target"
+        prediction_column="prediction", target_column="target"
     )
 
     with pytest.raises(Exception):
         validator(df_gap, split_fn_gap, model, eval_fn_gap, drop_empty_folds=False)
 
     validator_log = validator(
-        df_gap,
-        split_fn_gap,
-        model,
-        eval_fn_gap,
-        drop_empty_folds=True
+        df_gap, split_fn_gap, model, eval_fn_gap, drop_empty_folds=True
     )["validator_log"]
 
     assert len(validator_log[0]) == 3
-    assert len(validator_log[0]['eval_results']) == 1
+    assert len(validator_log[0]["eval_results"]) == 1
 
 
 def test_parallel_validator():
@@ -181,10 +219,10 @@ def test_parallel_validator():
     validator_log = result["validator_log"]
 
     assert len(validator_log) == 2
-    assert validator_log[0]['fold_num'] == 0
-    assert result['train_log'][0]['xgb_classification_learner']['features'] == ['f1']
+    assert validator_log[0]["fold_num"] == 0
+    assert result["train_log"][0]["xgb_classification_learner"]["features"] == ["f1"]
 
-    assert len(validator_log[0]['eval_results']) == 3
+    assert len(validator_log[0]["eval_results"]) == 3
 
-    assert validator_log[1]['fold_num'] == 1
-    assert len(validator_log[1]['eval_results']) == 1
+    assert validator_log[1]["fold_num"] == 1
+    assert len(validator_log[1]["eval_results"]) == 1

--- a/tests/validation/test_validator.py
+++ b/tests/validation/test_validator.py
@@ -13,8 +13,6 @@ from fklearn.validation.validator import (
 )
 from fklearn.validation.perturbators import perturbator, nullify
 import pytest
-import sklearn
-import lightgbm
 
 
 def train_fn(df):

--- a/tests/validation/test_validator.py
+++ b/tests/validation/test_validator.py
@@ -1,10 +1,16 @@
 import warnings
+from datetime import datetime, timedelta
 
 import pandas as pd
 from toolz.functoolz import identity
 
+from fklearn.training.classification import lgbm_classification_learner
+from fklearn.validation import splitters, evaluators
 from fklearn.validation.validator import validator_iteration, validator, parallel_validator
 from fklearn.validation.perturbators import perturbator, nullify
+import pytest
+import sklearn
+import lightgbm
 
 
 def train_fn(df):
@@ -67,23 +73,106 @@ def test_validator_iteration():
 
 
 def test_validator():
-    result = validator(data, split_fn, train_fn, eval_fn, perturb_fn_train, perturb_fn_test)
+    model = lgbm_classification_learner(
+        target="target",
+        features=["feat1", "feat2"],
+        extra_params={"verbose": -1}
+    )
 
-    validator_log = result["validator_log"]
+    df_no_gap = pd.DataFrame({
+        "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
+        "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
+        "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
+        "date": [
+            datetime.strptime(d, "%Y-%m-%d") for d in ["2021-01-01", "2021-01-09", "2021-02-08",
+                                                       "2021-02-10", "2021-03-20", "2021-03-11",
+                                                       "2021-04-01", "2021-04-02", "2021-05-15",
+                                                       "2021-05-15", "2021-06-01", "2021-06-02",
+                                                       "2021-07-15", "2021-07-15"]
+        ]
+    })
 
-    assert len(validator_log) == 2
+    split_fn_no_gap = splitters.forward_stability_curve_time_splitter(
+        training_time_start=df_no_gap["date"].min(),
+        training_time_end=df_no_gap["date"].min() + timedelta(60),
+        time_column="date",
+        step=timedelta(30),
+        holdout_size=timedelta(30)
+    )
+
+    eval_fn_no_gap = evaluators.roc_auc_evaluator(
+        prediction_column="prediction",
+        target_column="target"
+    )
+
+    perturb_fn_train_no_gap = identity
+    perturb_fn_test_no_gap = perturbator(cols=['feat1'], corruption_fn=nullify(perc=0.25))
+
+    result_no_gap = validator(df_no_gap, split_fn_no_gap, model, eval_fn_no_gap, perturb_fn_train_no_gap, perturb_fn_test_no_gap)
+
+    validator_log = result_no_gap["validator_log"]
+
+    assert len(validator_log[1]) == 4
     assert validator_log[0]['fold_num'] == 0
-    assert result['train_log']['xgb_classification_learner']['features'] == ['f1']
+    assert result_no_gap['train_log']['lgbm_classification_learner']['features'] == ['feat1', 'feat2']
 
-    assert len(validator_log[0]['eval_results']) == 3
+    assert len(validator_log[0]['eval_results']) == 1
 
     assert validator_log[1]['fold_num'] == 1
     assert len(validator_log[1]['eval_results']) == 1
 
-    perturbator_log = result["perturbator_log"]
+    perturbator_log = result_no_gap["perturbator_log"]
 
     assert perturbator_log['perturbated_train'] == []
-    assert perturbator_log['perturbated_test'] == ['rows']
+    assert perturbator_log['perturbated_test'] == ['feat1']
+
+
+def test_validator_with_gap():
+    model = lgbm_classification_learner(
+        target="target",
+        features=["feat1", "feat2"],
+        extra_params={"verbose": -1}
+    )
+
+    df_gap = pd.DataFrame({
+        "feat1": [1, 2, 1, 5, 2, 1, 5, 6, 8, 1, 7, 5, 1, 2],
+        "feat2": [1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0],
+        "target": [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0],
+        "date": [
+            datetime.strptime(d, "%Y-%m-%d") for d in ["2021-01-01", "2021-01-09", "2021-02-08",
+                                                       "2021-02-10", "2021-03-20", "2021-03-11",
+                                                       "2021-07-01", "2021-07-02", "2021-09-15",
+                                                       "2021-09-15", "2021-10-01", "2021-10-02",
+                                                       "2021-11-15", "2021-11-15"]
+        ]
+    })
+
+    split_fn_gap = splitters.forward_stability_curve_time_splitter(
+        training_time_start=df_gap["date"].min(),
+        training_time_end=df_gap["date"].min() + timedelta(60),
+        time_column="date",
+        step=timedelta(30),
+        holdout_size=timedelta(30)
+    )
+
+    eval_fn_gap = evaluators.roc_auc_evaluator(
+        prediction_column="prediction",
+        target_column="target"
+    )
+
+    with pytest.raises(Exception):
+        validator(df_gap, split_fn_gap, model, eval_fn_gap, drop_empty_folds=False)
+
+    validator_log = validator(
+        df_gap,
+        split_fn_gap,
+        model,
+        eval_fn_gap,
+        drop_empty_folds=True
+    )["validator_log"]
+
+    assert len(validator_log[0]) == 3
+    assert len(validator_log[0]['eval_results']) == 1
 
 
 def test_parallel_validator():


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
Depending on the data - if it has gaps that makes all the training start and end date be NaT, the validator function will break.

### Description of the changes proposed in the pull request
This PR should fix the mentioned issue by skipping the folds where there is no training or testing data and saving these failure logs. The changes will only take effect if "drop_empty_folds" is set to be True, otherwise, the implementation of this function will remain as it was before.

### Related PR
- https://github.com/nubank/fklearn/pull/210
