### PR TITLE
Replaced default argument min_df from 20 to 0 on TFIDF

### DIFF
--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -446,7 +446,7 @@ def nlp_logistic_classification_learner(df: pd.DataFrame,
     """
 
     # set default params
-    default_vect_params = {"strip_accents": "unicode", "min_df": 20}
+    default_vect_params = {"strip_accents": "unicode", "min_df": 0}
     merged_vect_params = default_vect_params if not vectorizer_params else merge(default_vect_params, vectorizer_params)
 
     default_clf_params = {"C": 0.1, "multi_class": "ovr", "solver": "liblinear"}

--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -446,7 +446,7 @@ def nlp_logistic_classification_learner(df: pd.DataFrame,
     """
 
     # set default params
-    default_vect_params = {"strip_accents": "unicode", "min_df": 0}
+    default_vect_params = {"strip_accents": "unicode", "min_df": 1}
     merged_vect_params = default_vect_params if not vectorizer_params else merge(default_vect_params, vectorizer_params)
 
     default_clf_params = {"C": 0.1, "multi_class": "ovr", "solver": "liblinear"}


### PR DESCRIPTION
On sklearn min_df defaults to 0, it should default to 0 as well in fklearn. This argument is not specified in the docstring and was messing up with the performance of my sentiment classifier. I lost 20 points of recall because of this argument and had to spent hours figuring out that this was the problem. Could we change that argument to be consistent with sklearn?