### PR TITLE
Add MinMax Scaler

### DIFF
--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -893,11 +893,9 @@ def minmax_scaler(df: pd.DataFrame,
                   columns_to_minmax_scale: List[str],
                   feature_range: Tuple[float, float] = (0, 1)) -> LearnerReturnType:
     """
-    Transform features by scaling each feature to a given range.
+    Fits a minmax scaler to the dataset using a desired range.
 
-    This estimator scales and translates each feature individually such
-    that it is in the given range on the training set, e.g. between zero
-    and one.
+    The scaler will replace the original values in the dataset.
 
     Parameters
     ----------

--- a/tests/training/test_transformation.py
+++ b/tests/training/test_transformation.py
@@ -20,6 +20,7 @@ from fklearn.training.transformation import (
     onehot_categorizer,
     target_categorizer,
     standard_scaler,
+    minmax_scaler,
     ecdfer,
     discrete_ecdfer,
     custom_transformer,
@@ -1235,6 +1236,111 @@ def test_standard_scaler():
             axis=1,
         ).values,
         pred_fn4(input_df_test).values,
+        decimal=5,
+    )
+
+
+def test_minmax_scaler():
+    input_df_train = pd.DataFrame({"feat1_num": [1.0, 0.5, 100.0],
+                                   "feat2_num":[-4.5, 10.2, 7.4]})
+
+    expected_output_train = pd.DataFrame(
+        {"feat1_num": [0.005025, 0.0, 1.0],
+         "feat2_num": [0.0, 1.0, 0.809524]}
+    )
+
+    input_df_test = pd.DataFrame({"feat1_num": [2.0, 4.0, 8.0],
+                                  "feat2_num": [-8.0, -4.0, 8.0]})
+
+    expected_output_test = pd.DataFrame(
+        {"feat1_num": [0.015075, 0.035176, 0.075377],
+         "feat2_num": [-0.238095, 0.034014, 0.850340]}
+    )
+
+    pred_fn1, data1, log = minmax_scaler(input_df_train, ["feat1_num", "feat2_num"])
+    pred_fn2, data2, log = minmax_scaler(
+        input_df_train, ["feat1_num", "feat2_num"], suffix="_suffix"
+    )
+    pred_fn3, data3, log = minmax_scaler(
+        input_df_train, ["feat1_num", "feat2_num"], prefix="prefix_"
+    )
+    pred_fn4, data4, log = minmax_scaler(
+        input_df_train,
+        ["feat1_num"],
+        columns_mapping={"feat1_num": "feat1_num_raw"},
+    )
+
+    assert_almost_equal(expected_output_train.values, data1.values, decimal=5)
+    assert_almost_equal(
+        expected_output_test.values, pred_fn1(input_df_test).values, decimal=5
+    )
+
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_train,
+                input_df_train[["feat1_num", "feat2_num"]].copy().add_suffix("_suffix"),
+            ],
+            axis=1,
+        ).values,
+        data2.values,
+        decimal=5,
+    )
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_test,
+                input_df_test[["feat1_num", "feat2_num"]].copy().add_suffix("_suffix"),
+            ],
+            axis=1,
+        ).values,
+        pred_fn2(input_df_test).values,
+        decimal=5,
+    )
+
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_train,
+                input_df_train[["feat1_num", "feat2_num"]].copy().add_prefix("prefix_"),
+            ],
+            axis=1,
+        ).values,
+        data3.values,
+        decimal=5,
+    )
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_test,
+                input_df_test[["feat1_num", "feat2_num"]].copy().add_prefix("prefix_"),
+            ],
+            axis=1,
+        ).values,
+        pred_fn3(input_df_test).values,
+        decimal=5,
+    )
+
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_train[["feat1_num"]],
+                input_df_train[["feat1_num"]].copy().add_suffix("_raw"),
+            ],
+            axis=1,
+        ).values,
+        data4[["feat1_num", "feat1_num_raw"]].values,
+        decimal=5,
+    )
+    assert_almost_equal(
+        pd.concat(
+            [
+                expected_output_test[["feat1_num"]],
+                input_df_test[["feat1_num"]].copy().add_suffix("_raw"),
+            ],
+            axis=1,
+        ).values,
+        pred_fn4(input_df_test)[["feat1_num", "feat1_num_raw"]].values,
         decimal=5,
     )
 

--- a/tests/tuning/test_parameter_tuners.py
+++ b/tests/tuning/test_parameter_tuners.py
@@ -10,10 +10,10 @@ from fklearn.validation.splitters import out_of_time_and_space_splitter
 
 def test_random_search_tuner(tmpdir):
     train_set = pd.DataFrame({
-        'id': ["id1", "id2", "id3", "id3"],
-        'date': pd.to_datetime(["2016-01-01", "2016-02-01", "2016-03-01", "2016-04-01"]),
-        'x': [.2, .9, .3, .3],
-        'target': [0, 1, 0, 1]
+        'id': ["id1", "id2", "id3", "id3", "id4", "id5", "id6"],
+        'date': pd.to_datetime(["2016-01-01", "2016-02-01", "2016-03-01", "2016-05-01", "2016-06-01", "2016-07-01", "2016-08-01"]),
+        'x': [.2, .9, .3, .3, .4, .4, .5],
+        'target': [0, 1, 0, 1, 0, 1, 1]
     })
 
     eval_fn = roc_auc_evaluator(target_column="target")
@@ -45,10 +45,10 @@ def test_random_search_tuner(tmpdir):
 
 def test_grid_search_tuner(tmpdir):
     train_set = pd.DataFrame({
-        'id': ["id1", "id2", "id3", "id3"],
-        'date': pd.to_datetime(["2016-01-01", "2016-02-01", "2016-03-01", "2016-04-01"]),
-        'x': [.2, .9, .3, .3],
-        'target': [0, 1, 0, 1]
+        'id': ["id1", "id2", "id3", "id3", "id4", "id5", "id6"],
+        'date': pd.to_datetime(["2016-01-01", "2016-02-01", "2016-03-01", "2016-05-01", "2016-06-01", "2016-07-01", "2016-08-01"]),
+        'x': [.2, .9, .3, .3, .4, .4, .5],
+        'target': [0, 1, 0, 1, 0, 1, 1]
     })
 
     eval_fn = roc_auc_evaluator(target_column="target")


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed
- [x] ~Issue: closes NA~

### Background context
We're adding a MinMax scaler to `fklearn.training` module, often used in neural networks.

### Description of the changes proposed in the pull request
We've made two changes:
1. Adding the MinMax scaler to `fklearn.training` module.
2. Adding tests of the MinMax scaler.

### Related PRs
NA

### Where should the reviewer start?
With the definition of the MinMax scaler itself.

### Remaining problems or questions
NA
