### PR TITLE
Specifies version of setuptools in requirements to avoid clash with numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ joblib>=0.13.2,<2
 numpy>=1.16.4,<2
 pandas>=0.24.1,<2
 scikit-learn>=0.21.2,<0.24.0
+setuptools<=65.5.0
 statsmodels>=0.9.0,<1
 toolz>=0.9.0,<1


### PR DESCRIPTION
### Status
**HOLD**

### Todo list
The change does not require documentation nor additional tests

### Background context
There has been a clash reported among numpy and setuptools related to the latest version of setuptools (65.6.0), this issue is described [here](https://github.com/pypa/setuptools/issues/3693).

### Description of the changes proposed in the pull request
We specify the version of setuptools in requirements.txt to be below 65.6.0 to avoid the problem.
