### PR TITLE
Add kwargs and multi-class on Precision and Recall evaluators

### DIFF
--- a/notebooks/catboost_demo.ipynb
+++ b/notebooks/catboost_demo.ipynb
@@ -418,7 +418,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -432,9 +432,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/fklearn/causal/debias.py
+++ b/src/fklearn/causal/debias.py
@@ -12,12 +12,14 @@ from typing import Dict, Any
 
 
 @curry
-def debias_with_regression_formula(df: pd.DataFrame,
-                                   treatment_column: str,
-                                   outcome_column: str,
-                                   confounder_formula: str,
-                                   suffix: str = "_debiased",
-                                   denoise: bool = True) -> pd.DataFrame:
+def debias_with_regression_formula(
+    df: pd.DataFrame,
+    treatment_column: str,
+    outcome_column: str,
+    confounder_formula: str,
+    suffix: str = "_debiased",
+    denoise: bool = True,
+) -> pd.DataFrame:
     """
     Frisch-Waugh-Lovell style debiasing with linear regression. With R formula to define confounders.
     To debias, we
@@ -66,12 +68,14 @@ def debias_with_regression_formula(df: pd.DataFrame,
 
 
 @curry
-def debias_with_regression(df: pd.DataFrame,
-                           treatment_column: str,
-                           outcome_column: str,
-                           confounder_columns: List[str],
-                           suffix: str = "_debiased",
-                           denoise: bool = True) -> pd.DataFrame:
+def debias_with_regression(
+    df: pd.DataFrame,
+    treatment_column: str,
+    outcome_column: str,
+    confounder_columns: List[str],
+    suffix: str = "_debiased",
+    denoise: bool = True,
+) -> pd.DataFrame:
     """
     Frisch-Waugh-Lovell style debiasing with linear regression.
     To debias, we
@@ -115,18 +119,20 @@ def debias_with_regression(df: pd.DataFrame,
 
     model.fit(df[confounder_columns], df[cols_to_debias])
 
-    debiased = (df[cols_to_debias] - model.predict(df[confounder_columns]) + df[cols_to_debias].mean())
+    debiased = df[cols_to_debias] - model.predict(df[confounder_columns]) + df[cols_to_debias].mean()
 
     return df.assign(**{c + suffix: debiased[c] for c in cols_to_debias})
 
 
 @curry
-def debias_with_fixed_effects(df: pd.DataFrame,
-                              treatment_column: str,
-                              outcome_column: str,
-                              confounder_columns: List[str],
-                              suffix: str = "_debiased",
-                              denoise: bool = True) -> pd.DataFrame:
+def debias_with_fixed_effects(
+    df: pd.DataFrame,
+    treatment_column: str,
+    outcome_column: str,
+    confounder_columns: List[str],
+    suffix: str = "_debiased",
+    denoise: bool = True,
+) -> pd.DataFrame:
     """
     Returns a dataframe with the debiased columns with suffix appended to the name
 
@@ -172,16 +178,18 @@ def debias_with_fixed_effects(df: pd.DataFrame,
 
 
 @curry
-def debias_with_double_ml(df: pd.DataFrame,
-                          treatment_column: str,
-                          outcome_column: str,
-                          confounder_columns: List[str],
-                          ml_regressor: RegressorMixin = GradientBoostingRegressor,
-                          extra_params: Dict[str, Any] = None,
-                          cv: int = 5,
-                          suffix: str = "_debiased",
-                          denoise: bool = True,
-                          seed: int = 123) -> pd.DataFrame:
+def debias_with_double_ml(
+    df: pd.DataFrame,
+    treatment_column: str,
+    outcome_column: str,
+    confounder_columns: List[str],
+    ml_regressor: RegressorMixin = GradientBoostingRegressor,
+    extra_params: Dict[str, Any] = None,
+    cv: int = 5,
+    suffix: str = "_debiased",
+    denoise: bool = True,
+    seed: int = 123,
+) -> pd.DataFrame:
     """
     Frisch-Waugh-Lovell style debiasing with ML model.
     To debias, we

--- a/src/fklearn/causal/effects.py
+++ b/src/fklearn/causal/effects.py
@@ -2,14 +2,18 @@ import pandas as pd
 from toolz import curry
 from typing import Dict, Callable
 
-from fklearn.validation.evaluators import (spearman_evaluator, correlation_evaluator, linear_coefficient_evaluator,
-                                           exponential_coefficient_evaluator, logistic_coefficient_evaluator)
+from fklearn.validation.evaluators import (
+    spearman_evaluator,
+    correlation_evaluator,
+    linear_coefficient_evaluator,
+    exponential_coefficient_evaluator,
+    logistic_coefficient_evaluator,
+)
 
 
-def _apply_effect(evaluator: Callable[..., Dict[str, float]],
-                  df: pd.DataFrame,
-                  treatment_column: str,
-                  outcome_column: str) -> float:
+def _apply_effect(
+    evaluator: Callable[..., Dict[str, float]], df: pd.DataFrame, treatment_column: str, outcome_column: str
+) -> float:
     return evaluator(df, treatment_column, outcome_column, eval_name="effect")["effect"]
 
 

--- a/src/fklearn/causal/validation/auc.py
+++ b/src/fklearn/causal/validation/auc.py
@@ -7,162 +7,201 @@ from fklearn.causal.effects import linear_effect
 
 
 @curry
-def area_under_the_cumulative_effect_curve(df: pd.DataFrame,
-                                           treatment: str,
-                                           outcome: str,
-                                           prediction: str,
-                                           min_rows: int = 30,
-                                           steps: int = 100,
-                                           effect_fn: EffectFnType = linear_effect) -> float:
+def area_under_the_cumulative_effect_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> float:
     """
-     Orders the dataset by prediction and computes the area under the cumulative effect curve, according to that
-     ordering.
+    Orders the dataset by prediction and computes the area under the cumulative effect curve, according to that
+    ordering.
 
-     Parameters
-     ----------
-     df : Pandas' DataFrame
-         A Pandas' DataFrame with target and prediction scores.
+    Parameters
+    ----------
+    df : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
 
-     treatment : str
-         The name of the treatment column in `df`.
+    treatment : str
+        The name of the treatment column in `df`.
 
-     outcome : Strings
-         The name of the outcome column in `df`.
+    outcome : Strings
+        The name of the outcome column in `df`.
 
-     prediction : Strings
-         The name of the prediction column in `df`.
+    prediction : Strings
+        The name of the prediction column in `df`.
 
-     min_rows : int
-         Minimum number of observations needed to have a valid result.
+    min_rows : int
+        Minimum number of observations needed to have a valid result.
 
-     steps : Integer
-         The number of cumulative steps to iterate when accumulating the effect
+    steps : Integer
+        The number of cumulative steps to iterate when accumulating the effect
 
-     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
-         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
-         of the outcome column.
+    effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+        A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+        of the outcome column.
 
 
-     Returns
-     ----------
-     area_under_the_cumulative_gain_curve: float
-         The area under the cumulative gain curve according to the predictions ordering.
-     """
+    Returns
+    ----------
+    area_under_the_cumulative_gain_curve: float
+        The area under the cumulative gain curve according to the predictions ordering.
+    """
 
     ate = effect_fn(df, treatment, outcome)
     size = df.shape[0]
     n_rows = list(range(min_rows, size, size // steps)) + [size]
     step_sizes = [min_rows] + [t - s for s, t in zip(n_rows, n_rows[1:])]
 
-    cum_effect = cumulative_effect_curve(df=df, treatment=treatment, outcome=outcome, prediction=prediction,
-                                         min_rows=min_rows, steps=steps, effect_fn=effect_fn)
+    cum_effect = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
 
     return abs(sum([(effect - ate) * (step_size / size) for effect, step_size in zip(cum_effect, step_sizes)]))
 
 
 @curry
-def area_under_the_cumulative_gain_curve(df: pd.DataFrame,
-                                         treatment: str,
-                                         outcome: str,
-                                         prediction: str,
-                                         min_rows: int = 30,
-                                         steps: int = 100,
-                                         effect_fn: EffectFnType = linear_effect) -> float:
+def area_under_the_cumulative_gain_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> float:
     """
-     Orders the dataset by prediction and computes the area under the cumulative gain curve, according to that ordering.
+    Orders the dataset by prediction and computes the area under the cumulative gain curve, according to that ordering.
 
-     Parameters
-     ----------
-     df : Pandas' DataFrame
-         A Pandas' DataFrame with target and prediction scores.
+    Parameters
+    ----------
+    df : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
 
-     treatment : Strings
-         The name of the treatment column in `df`.
+    treatment : Strings
+        The name of the treatment column in `df`.
 
-     outcome : Strings
-         The name of the outcome column in `df`.
+    outcome : Strings
+        The name of the outcome column in `df`.
 
-     prediction : Strings
-         The name of the prediction column in `df`.
+    prediction : Strings
+        The name of the prediction column in `df`.
 
-     min_rows : Integer
-         Minimum number of observations needed to have a valid result.
+    min_rows : Integer
+        Minimum number of observations needed to have a valid result.
 
-     steps : Integer
-         The number of cumulative steps to iterate when accumulating the effect
+    steps : Integer
+        The number of cumulative steps to iterate when accumulating the effect
 
-     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
-         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
-         of the outcome column.
+    effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+        A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+        of the outcome column.
 
 
-     Returns
-     ----------
-     area_under_the_cumulative_gain_curve: float
-         The area under the cumulative gain curve according to the predictions ordering.
-     """
+    Returns
+    ----------
+    area_under_the_cumulative_gain_curve: float
+        The area under the cumulative gain curve according to the predictions ordering.
+    """
 
     size = df.shape[0]
     n_rows = list(range(min_rows, size, size // steps)) + [size]
     step_sizes = [min_rows] + [t - s for s, t in zip(n_rows, n_rows[1:])]
 
-    cum_effect = cumulative_effect_curve(df=df, treatment=treatment, outcome=outcome, prediction=prediction,
-                                         min_rows=min_rows, steps=steps, effect_fn=effect_fn)
+    cum_effect = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
 
-    return abs(sum([effect * (rows / size) * (step_size / size)
-                    for rows, effect, step_size in zip(n_rows, cum_effect, step_sizes)]))
+    return abs(
+        sum(
+            [
+                effect * (rows / size) * (step_size / size)
+                for rows, effect, step_size in zip(n_rows, cum_effect, step_sizes)
+            ]
+        )
+    )
 
 
 @curry
-def area_under_the_relative_cumulative_gain_curve(df: pd.DataFrame,
-                                                  treatment: str,
-                                                  outcome: str,
-                                                  prediction: str,
-                                                  min_rows: int = 30,
-                                                  steps: int = 100,
-                                                  effect_fn: EffectFnType = linear_effect) -> float:
+def area_under_the_relative_cumulative_gain_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> float:
     """
-     Orders the dataset by prediction and computes the area under the relative cumulative gain curve, according to that
-      ordering.
+    Orders the dataset by prediction and computes the area under the relative cumulative gain curve, according to that
+     ordering.
 
-     Parameters
-     ----------
-     df : Pandas' DataFrame
-         A Pandas' DataFrame with target and prediction scores.
+    Parameters
+    ----------
+    df : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
 
-     treatment : Strings
-         The name of the treatment column in `df`.
+    treatment : Strings
+        The name of the treatment column in `df`.
 
-     outcome : Strings
-         The name of the outcome column in `df`.
+    outcome : Strings
+        The name of the outcome column in `df`.
 
-     prediction : Strings
-         The name of the prediction column in `df`.
+    prediction : Strings
+        The name of the prediction column in `df`.
 
-     min_rows : Integer
-         Minimum number of observations needed to have a valid result.
+    min_rows : Integer
+        Minimum number of observations needed to have a valid result.
 
-     steps : Integer
-         The number of cumulative steps to iterate when accumulating the effect
+    steps : Integer
+        The number of cumulative steps to iterate when accumulating the effect
 
-     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
-         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
-         of the outcome column.
+    effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+        A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+        of the outcome column.
 
 
-     Returns
-     ----------
-     area under the relative cumulative gain curve: float
-         The area under the relative cumulative gain curve according to the predictions ordering.
-     """
+    Returns
+    ----------
+    area under the relative cumulative gain curve: float
+        The area under the relative cumulative gain curve according to the predictions ordering.
+    """
 
     ate = effect_fn(df, treatment, outcome)
     size = df.shape[0]
     n_rows = list(range(min_rows, size, size // steps)) + [size]
     step_sizes = [min_rows] + [t - s for s, t in zip(n_rows, n_rows[1:])]
 
-    cum_effect = cumulative_effect_curve(df=df, treatment=treatment, outcome=outcome, prediction=prediction,
-                                         min_rows=min_rows, steps=steps, effect_fn=effect_fn)
+    cum_effect = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
 
-    return abs(sum([(effect - ate) * (rows / size) * (step_size / size)
-                    for rows, effect, step_size in zip(n_rows, cum_effect, step_sizes)]))
+    return abs(
+        sum(
+            [
+                (effect - ate) * (rows / size) * (step_size / size)
+                for rows, effect, step_size in zip(n_rows, cum_effect, step_sizes)
+            ]
+        )
+    )

--- a/src/fklearn/causal/validation/cate.py
+++ b/src/fklearn/causal/validation/cate.py
@@ -5,9 +5,7 @@ from fklearn.types import EvalReturnType, UncurriedEvalFnType
 from fklearn.validation.evaluators import r2_evaluator
 
 
-def _validate_test_and_control_groups(test_data: pd.DataFrame,
-                                      group_column: str,
-                                      control_group_name: str) -> str:
+def _validate_test_and_control_groups(test_data: pd.DataFrame, group_column: str, control_group_name: str) -> str:
     """
     Checks whether `test_data` has data on exactly two different experiment groups: test and control. Also returns the
     name of the test group.
@@ -35,24 +33,20 @@ def _validate_test_and_control_groups(test_data: pd.DataFrame,
 
     n_groups = len(unique_values)
     if n_groups != 2:
-        raise RuntimeError(
-            "Exactly 2 groups are required for delta evaluations. found {}".format(
-                n_groups
-            )
-        )
-    return (
-        unique_values[0] if control_group_name == unique_values[1] else unique_values[1]
-    )
+        raise RuntimeError("Exactly 2 groups are required for delta evaluations. found {}".format(n_groups))
+    return unique_values[0] if control_group_name == unique_values[1] else unique_values[1]
 
 
-def cate_mean_by_bin(test_data: pd.DataFrame,
-                     group_column: str,
-                     control_group_name: str,
-                     bin_column: str,
-                     n_bins: int,
-                     allow_dropped_bins: bool,
-                     prediction_column: str,
-                     target_column: str) -> pd.DataFrame:
+def cate_mean_by_bin(
+    test_data: pd.DataFrame,
+    group_column: str,
+    control_group_name: str,
+    bin_column: str,
+    n_bins: int,
+    allow_dropped_bins: bool,
+    prediction_column: str,
+    target_column: str,
+) -> pd.DataFrame:
     """
     Computes a dataframe with predicted and actual CATEs by bins of a given column.
 
@@ -89,20 +83,14 @@ def cate_mean_by_bin(test_data: pd.DataFrame,
     gb: DataFrame
         The grouped dataframe with actual and predicted CATEs by bin.
     """
-    test_group_name = _validate_test_and_control_groups(
-        test_data, group_column, control_group_name
-    )
+    test_group_name = _validate_test_and_control_groups(test_data, group_column, control_group_name)
 
     test_after_control = test_group_name > control_group_name
 
     quantile_column = bin_column + "_q" + str(n_bins)
     duplicates = "drop" if allow_dropped_bins else "raise"
     test_data_binned = test_data.assign(
-        **{
-            quantile_column: pd.qcut(
-                test_data[bin_column], n_bins, duplicates=duplicates
-            )
-        }
+        **{quantile_column: pd.qcut(test_data[bin_column], n_bins, duplicates=duplicates)}
     )
 
     gb_columns = [group_column, quantile_column]
@@ -117,16 +105,18 @@ def cate_mean_by_bin(test_data: pd.DataFrame,
 
 
 @curry
-def cate_mean_by_bin_meta_evaluator(test_data: pd.DataFrame,
-                                    group_column: str,
-                                    control_group_name: str,
-                                    bin_column: str,
-                                    n_bins: int,
-                                    allow_dropped_bins: bool = False,
-                                    inner_evaluator: UncurriedEvalFnType = r2_evaluator,
-                                    eval_name: str = None,
-                                    prediction_column: str = "prediction",
-                                    target_column: str = "target") -> EvalReturnType:
+def cate_mean_by_bin_meta_evaluator(
+    test_data: pd.DataFrame,
+    group_column: str,
+    control_group_name: str,
+    bin_column: str,
+    n_bins: int,
+    allow_dropped_bins: bool = False,
+    inner_evaluator: UncurriedEvalFnType = r2_evaluator,
+    eval_name: str = None,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+) -> EvalReturnType:
     """
     Evaluates the predictions of a causal model that outputs treatment outcomes w.r.t. its capabilities to predict the
     CATE.
@@ -190,13 +180,7 @@ def cate_mean_by_bin_meta_evaluator(test_data: pd.DataFrame,
         )
 
     if eval_name is None:
-        eval_name = (
-            "cate_mean_by_bin_"
-            + bin_column
-            + "[{}q]".format(n_bins)
-            + "__"
-            + inner_evaluator.__name__
-        )
+        eval_name = "cate_mean_by_bin_" + bin_column + "[{}q]".format(n_bins) + "__" + inner_evaluator.__name__
 
     return inner_evaluator(
         test_data=gb,

--- a/src/fklearn/causal/validation/curves.py
+++ b/src/fklearn/causal/validation/curves.py
@@ -9,12 +9,14 @@ from fklearn.causal.effects import linear_effect
 
 
 @curry
-def effect_by_segment(df: pd.DataFrame,
-                      treatment: str,
-                      outcome: str,
-                      prediction: str,
-                      segments: int = 10,
-                      effect_fn: EffectFnType = linear_effect) -> pd.Series:
+def effect_by_segment(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    segments: int = 10,
+    effect_fn: EffectFnType = linear_effect,
+) -> pd.Series:
     """
     Segments the dataset by a prediction's quantile and estimates the treatment effect by segment.
 
@@ -46,20 +48,23 @@ def effect_by_segment(df: pd.DataFrame,
     """
 
     effect_fn_partial = partial(effect_fn, treatment_column=treatment, outcome_column=outcome)
-    return (df
-            .assign(**{f"{prediction}_band": pd.qcut(df[prediction], q=segments)})
-            .groupby(f"{prediction}_band")
-            .apply(effect_fn_partial))
+    return (
+        df.assign(**{f"{prediction}_band": pd.qcut(df[prediction], q=segments)})
+        .groupby(f"{prediction}_band")
+        .apply(effect_fn_partial)
+    )
 
 
 @curry
-def cumulative_effect_curve(df: pd.DataFrame,
-                            treatment: str,
-                            outcome: str,
-                            prediction: str,
-                            min_rows: int = 30,
-                            steps: int = 100,
-                            effect_fn: EffectFnType = linear_effect) -> np.ndarray:
+def cumulative_effect_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> np.ndarray:
     """
     Orders the dataset by prediction and computes the cumulative effect curve according to that ordering
 
@@ -101,13 +106,15 @@ def cumulative_effect_curve(df: pd.DataFrame,
 
 
 @curry
-def cumulative_gain_curve(df: pd.DataFrame,
-                          treatment: str,
-                          outcome: str,
-                          prediction: str,
-                          min_rows: int = 30,
-                          steps: int = 100,
-                          effect_fn: EffectFnType = linear_effect) -> np.ndarray:
+def cumulative_gain_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> np.ndarray:
     """
     Orders the dataset by prediction and computes the cumulative gain (effect * proportional sample size) curve
      according to that ordering.
@@ -146,62 +153,78 @@ def cumulative_gain_curve(df: pd.DataFrame,
     size = df.shape[0]
     n_rows = list(range(min_rows, size, size // steps)) + [size]
 
-    cum_effect = cumulative_effect_curve(df=df, treatment=treatment, outcome=outcome, prediction=prediction,
-                                         min_rows=min_rows, steps=steps, effect_fn=effect_fn)
+    cum_effect = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
 
     return np.array([effect * (rows / size) for rows, effect in zip(n_rows, cum_effect)])
 
 
 @curry
-def relative_cumulative_gain_curve(df: pd.DataFrame,
-                                   treatment: str,
-                                   outcome: str,
-                                   prediction: str,
-                                   min_rows: int = 30,
-                                   steps: int = 100,
-                                   effect_fn: EffectFnType = linear_effect) -> np.ndarray:
+def relative_cumulative_gain_curve(
+    df: pd.DataFrame,
+    treatment: str,
+    outcome: str,
+    prediction: str,
+    min_rows: int = 30,
+    steps: int = 100,
+    effect_fn: EffectFnType = linear_effect,
+) -> np.ndarray:
     """
-     Orders the dataset by prediction and computes the relative cumulative gain curve curve according to that ordering.
-     The relative gain is simply the cumulative effect minus the Average Treatment Effect (ATE) times the relative
-     sample size.
+    Orders the dataset by prediction and computes the relative cumulative gain curve curve according to that ordering.
+    The relative gain is simply the cumulative effect minus the Average Treatment Effect (ATE) times the relative
+    sample size.
 
-     Parameters
-     ----------
-     df : Pandas' DataFrame
-         A Pandas' DataFrame with target and prediction scores.
+    Parameters
+    ----------
+    df : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
 
-     treatment : Strings
-         The name of the treatment column in `df`.
+    treatment : Strings
+        The name of the treatment column in `df`.
 
-     outcome : Strings
-         The name of the outcome column in `df`.
+    outcome : Strings
+        The name of the outcome column in `df`.
 
-     prediction : Strings
-         The name of the prediction column in `df`.
+    prediction : Strings
+        The name of the prediction column in `df`.
 
-     min_rows : Integer
-         Minimum number of observations needed to have a valid result.
+    min_rows : Integer
+        Minimum number of observations needed to have a valid result.
 
-     steps : Integer
-         The number of cumulative steps to iterate when accumulating the effect
+    steps : Integer
+        The number of cumulative steps to iterate when accumulating the effect
 
-     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
-         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
-         of the outcome column.
+    effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+        A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+        of the outcome column.
 
 
-     Returns
-     ----------
-     relative cumulative gain curve: float
-         The relative cumulative gain according to the predictions ordering.
-     """
+    Returns
+    ----------
+    relative cumulative gain curve: float
+        The relative cumulative gain according to the predictions ordering.
+    """
 
     ate = effect_fn(df, treatment, outcome)
     size = df.shape[0]
     n_rows = list(range(min_rows, size, size // steps)) + [size]
 
-    cum_effect = cumulative_effect_curve(df=df, treatment=treatment, outcome=outcome, prediction=prediction,
-                                         min_rows=min_rows, steps=steps, effect_fn=effect_fn)
+    cum_effect = cumulative_effect_curve(
+        df=df,
+        treatment=treatment,
+        outcome=outcome,
+        prediction=prediction,
+        min_rows=min_rows,
+        steps=steps,
+        effect_fn=effect_fn,
+    )
 
     return np.array([(effect - ate) * (rows / size) for rows, effect in zip(n_rows, cum_effect)])
 
@@ -217,41 +240,41 @@ def effect_curves(
     effect_fn: EffectFnType = linear_effect,
 ) -> pd.DataFrame:
     """
-     Creates a dataset summarizing the effect curves: cumulative effect, cumulative gain and
-     relative cumulative gain. The dataset also contains two columns referencing the data
-     used to compute the curves at each step: number of samples and fraction of samples used.
-     Moreover one column indicating the cumulative gain for a corresponding random model is
-     also included as a benchmark.
+    Creates a dataset summarizing the effect curves: cumulative effect, cumulative gain and
+    relative cumulative gain. The dataset also contains two columns referencing the data
+    used to compute the curves at each step: number of samples and fraction of samples used.
+    Moreover one column indicating the cumulative gain for a corresponding random model is
+    also included as a benchmark.
 
-     Parameters
-     ----------
-     df : Pandas' DataFrame
-         A Pandas' DataFrame with target and prediction scores.
+    Parameters
+    ----------
+    df : Pandas' DataFrame
+        A Pandas' DataFrame with target and prediction scores.
 
-     treatment : Strings
-         The name of the treatment column in `df`.
+    treatment : Strings
+        The name of the treatment column in `df`.
 
-     outcome : Strings
-         The name of the outcome column in `df`.
+    outcome : Strings
+        The name of the outcome column in `df`.
 
-     prediction : Strings
-         The name of the prediction column in `df`.
+    prediction : Strings
+        The name of the prediction column in `df`.
 
-     min_rows : Integer
-         Minimum number of observations needed to have a valid result.
+    min_rows : Integer
+        Minimum number of observations needed to have a valid result.
 
-     steps : Integer
-         The number of cumulative steps to iterate when accumulating the effect
+    steps : Integer
+        The number of cumulative steps to iterate when accumulating the effect
 
-     effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
-         A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
-         of the outcome column.
+    effect_fn : function (df: pandas.DataFrame, treatment: str, outcome: str) -> int or Array of int
+        A function that computes the treatment effect given a dataframe, the name of the treatment column and the name
+        of the outcome column.
 
 
-     Returns
-     ----------
-     summary curves dataset: pd.DataFrame
-         The dataset with the results for multiple validation causal curves according to the predictions ordering.
+    Returns
+    ----------
+    summary curves dataset: pd.DataFrame
+        The dataset with the results for multiple validation causal curves according to the predictions ordering.
     """
 
     size: int = df.shape[0]

--- a/src/fklearn/common_docstrings.py
+++ b/src/fklearn/common_docstrings.py
@@ -1,12 +1,15 @@
-
 def learner_pred_fn_docstring(f_name: str, shap: bool = False) -> str:
-    shap_docstring = """
+    shap_docstring = (
+        """
     apply_shap : boolean, optional
         Creates a new output column named "shap" with SHAP values.
         SHAP values can be used for interpretability and feature importances.
         For more information, see https://github.com/slundberg/shap
 
-    """ if shap else ""
+    """
+        if shap
+        else ""
+    )
 
     docstring = """
     Predict function from %s
@@ -23,13 +26,17 @@ def learner_pred_fn_docstring(f_name: str, shap: bool = False) -> str:
         A `new_df`-like DataFrame with the same columns as the
         input `new_df` plus a column with predictions from the trained learner.
 
-    """ % (f_name, shap_docstring)
+    """ % (
+        f_name,
+        shap_docstring,
+    )
 
     return docstring
 
 
 def learner_return_docstring(model_name: str) -> str:
-    docstring = """
+    docstring = (
+        """
     Returns
     ----------
     p : function pandas.DataFrame -> pandas.DataFrame
@@ -41,7 +48,9 @@ def learner_return_docstring(model_name: str) -> str:
         column with predictions from the model.
 
     log : dict
-        A log-like Dict that stores information of the %s model.""" % model_name
+        A log-like Dict that stores information of the %s model."""
+        % model_name
+    )
 
     return docstring
 

--- a/src/fklearn/data/datasets.py
+++ b/src/fklearn/data/datasets.py
@@ -24,17 +24,22 @@ def make_tutorial_data(n: int) -> pd.DataFrame:
     """
     np.random.seed(1111)
 
-    dataset = pd.DataFrame({
-        "id": list(map(lambda x: "id%d" % x, np.random.randint(0, 100, n))),
-        "date": np.random.choice(pd.date_range("2015-01-01", periods=100), n),
-        "feature1": np.random.gamma(20, size=n),
-        "feature2": np.random.normal(40, size=n),
-        "feature3": np.random.choice(["a", "b", "c"], size=n)})
+    dataset = pd.DataFrame(
+        {
+            "id": list(map(lambda x: "id%d" % x, np.random.randint(0, 100, n))),
+            "date": np.random.choice(pd.date_range("2015-01-01", periods=100), n),
+            "feature1": np.random.gamma(20, size=n),
+            "feature2": np.random.normal(40, size=n),
+            "feature3": np.random.choice(["a", "b", "c"], size=n),
+        }
+    )
 
-    dataset["target"] = (dataset["feature1"]
-                         + dataset["feature2"]
-                         + dataset["feature3"].apply(lambda x: 0 if x == "a" else 30 if x == "b" else 10)
-                         + np.random.normal(0, 5, size=n))
+    dataset["target"] = (
+        dataset["feature1"]
+        + dataset["feature2"]
+        + dataset["feature3"].apply(lambda x: 0 if x == "a" else 30 if x == "b" else 10)
+        + np.random.normal(0, 5, size=n)
+    )
 
     # insert some NANs
     dataset.loc[np.random.randint(0, n, 100), "feature1"] = nan
@@ -68,20 +73,15 @@ def make_confounded_data(n: int) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFra
     """
 
     def get_severity(df: pd.DataFrame) -> np.ndarray:
-        return ((np.random.beta(1, 3, size=df.shape[0]) * (df["age"] < 30))
-                + (np.random.beta(3, 1.5, size=df.shape[0]) * (df["age"] >= 30)))
+        return (np.random.beta(1, 3, size=df.shape[0]) * (df["age"] < 30)) + (
+            np.random.beta(3, 1.5, size=df.shape[0]) * (df["age"] >= 30)
+        )
 
     def get_treatment(df: pd.DataFrame) -> pd.Series:
-        return (.33 * df["sex"]
-                + 1.5 * df["severity"]
-                + 0.15 * np.random.normal(size=df.shape[0]) > 0.8).astype(float)
+        return (0.33 * df["sex"] + 1.5 * df["severity"] + 0.15 * np.random.normal(size=df.shape[0]) > 0.8).astype(float)
 
     def get_recovery(df: pd.DataFrame) -> np.ndarray:
-        return np.random.poisson(np.exp(2
-                                        + 0.5 * df["sex"]
-                                        + 0.03 * df["age"]
-                                        + df["severity"]
-                                        - df["medication"]))
+        return np.random.poisson(np.exp(2 + 0.5 * df["sex"] + 0.03 * df["age"] + df["severity"] - df["medication"]))
 
     np.random.seed(1111)
     sexes = np.random.randint(0, 2, size=n)
@@ -90,20 +90,20 @@ def make_confounded_data(n: int) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFra
 
     # random data
     df_rnd = pd.DataFrame(dict(sex=sexes, age=ages, medication=meds))
-    df_rnd['severity'] = get_severity(df_rnd)
-    df_rnd['recovery'] = get_recovery(df_rnd)
+    df_rnd["severity"] = get_severity(df_rnd)
+    df_rnd["recovery"] = get_recovery(df_rnd)
 
-    features = ['sex', 'age', 'severity', 'medication', 'recovery']
+    features = ["sex", "age", "severity", "medication", "recovery"]
     df_rnd = df_rnd[features]  # to enforce column order
 
     # obs data
     df_obs = df_rnd.copy()
-    df_obs['medication'] = get_treatment(df_obs)
-    df_obs['recovery'] = get_recovery(df_obs)
+    df_obs["medication"] = get_treatment(df_obs)
+    df_obs["recovery"] = get_recovery(df_obs)
 
     # caunter_factual data
     df_ctf = df_obs.copy()
-    df_ctf['medication'] = ((df_ctf['medication'] == 1) ^ 1).astype(float)
-    df_ctf['recovery'] = get_recovery(df_ctf)
+    df_ctf["medication"] = ((df_ctf["medication"] == 1) ^ 1).astype(float)
+    df_ctf["recovery"] = get_recovery(df_ctf)
 
     return df_rnd, df_obs, df_ctf

--- a/src/fklearn/exceptions/exceptions.py
+++ b/src/fklearn/exceptions/exceptions.py
@@ -3,29 +3,20 @@ from typing import Any, Dict, List
 
 class MultipleTreatmentsError(Exception):
     def __init__(
-        self,
-        msg: str = "Data contains multiple treatments.",
-        *args: List[Any],
-        **kwargs: Dict[str, Any]
+        self, msg: str = "Data contains multiple treatments.", *args: List[Any], **kwargs: Dict[str, Any]
     ) -> None:
         super().__init__(msg, *args, **kwargs)
 
 
 class MissingControlError(Exception):
     def __init__(
-        self,
-        msg: str = "Data does not contain the specified control.",
-        *args: List[Any],
-        **kwargs: Dict[str, Any]
+        self, msg: str = "Data does not contain the specified control.", *args: List[Any], **kwargs: Dict[str, Any]
     ) -> None:
         super().__init__(msg, *args, **kwargs)
 
 
 class MissingTreatmentError(Exception):
     def __init__(
-        self,
-        msg: str = "Data does not contain the specified treatment.",
-        *args: List[Any],
-        **kwargs: Dict[str, Any]
+        self, msg: str = "Data does not contain the specified treatment.", *args: List[Any], **kwargs: Dict[str, Any]
     ) -> None:
         super().__init__(msg, *args, **kwargs)

--- a/src/fklearn/preprocessing/rebalancing.py
+++ b/src/fklearn/preprocessing/rebalancing.py
@@ -3,8 +3,9 @@ from toolz import curry, partial
 
 
 @curry
-def rebalance_by_categorical(dataset: pd.DataFrame, categ_column: str, max_lines_by_categ: int = None,
-                             seed: int = 1) -> pd.DataFrame:
+def rebalance_by_categorical(
+    dataset: pd.DataFrame, categ_column: str, max_lines_by_categ: int = None, seed: int = 1
+) -> pd.DataFrame:
     """
     Resample dataset so that the result contains the same number of lines per category in  categ_column.
 
@@ -31,15 +32,23 @@ def rebalance_by_categorical(dataset: pd.DataFrame, categ_column: str, max_lines
     categs = dataset[categ_column].value_counts().to_dict()
     max_lines_by_categ = max_lines_by_categ if max_lines_by_categ else min(categs.values())
 
-    return pd.concat([(dataset
-                       .loc[dataset[categ_column] == categ, :]
-                       .sample(max_lines_by_categ, random_state=seed))
-                      for categ in list(categs.keys())])
+    return pd.concat(
+        [
+            (dataset.loc[dataset[categ_column] == categ, :].sample(max_lines_by_categ, random_state=seed))
+            for categ in list(categs.keys())
+        ]
+    )
 
 
 @curry
-def rebalance_by_continuous(dataset: pd.DataFrame, continuous_column: str, buckets: int, max_lines_by_categ: int = None,
-                            by_quantile: bool = False, seed: int = 1) -> pd.DataFrame:
+def rebalance_by_continuous(
+    dataset: pd.DataFrame,
+    continuous_column: str,
+    buckets: int,
+    max_lines_by_categ: int = None,
+    by_quantile: bool = False,
+    seed: int = 1,
+) -> pd.DataFrame:
     """
     Resample dataset so that the result contains the same number of lines per bucket in a continuous column.
 
@@ -71,9 +80,8 @@ def rebalance_by_continuous(dataset: pd.DataFrame, continuous_column: str, bucke
 
     bin_fn = partial(pd.qcut, q=buckets, duplicates="drop") if by_quantile else partial(pd.cut, bins=buckets)
 
-    return (dataset
-            .assign(bins=bin_fn(dataset[continuous_column]))
-            .pipe(rebalance_by_categorical(categ_column="bins",
-                                           max_lines_by_categ=max_lines_by_categ,
-                                           seed=seed))
-            .drop(columns=["bins"]))
+    return (
+        dataset.assign(bins=bin_fn(dataset[continuous_column]))
+        .pipe(rebalance_by_categorical(categ_column="bins", max_lines_by_categ=max_lines_by_categ, seed=seed))
+        .drop(columns=["bins"])
+    )

--- a/src/fklearn/preprocessing/schema.py
+++ b/src/fklearn/preprocessing/schema.py
@@ -13,7 +13,7 @@ def feature_duplicator(
     columns_to_duplicate: Optional[List[str]] = None,
     columns_mapping: Optional[Dict[str, str]] = None,
     prefix: Optional[str] = None,
-    suffix: Optional[str] = None
+    suffix: Optional[str] = None,
 ) -> LearnerReturnType:
     """
     Duplicates some columns in the dataframe.
@@ -53,10 +53,7 @@ def feature_duplicator(
     columns_final_mapping = (
         columns_mapping
         if columns_mapping is not None
-        else {
-            col: (prefix or '') + str(col) + (suffix or '')
-            for col in columns_to_duplicate
-        }
+        else {col: (prefix or "") + str(col) + (suffix or "") for col in columns_to_duplicate}
         if columns_to_duplicate
         else dict()
     )
@@ -68,12 +65,12 @@ def feature_duplicator(
     p.__doc__ = feature_duplicator.__doc__
 
     log: LearnerLogType = {
-        'feature_duplicator': {
-            'columns_to_duplicate': columns_to_duplicate,
-            'columns_mapping': columns_mapping,
-            'prefix': prefix,
-            'suffix': suffix,
-            'columns_final_mapping': columns_final_mapping,
+        "feature_duplicator": {
+            "columns_to_duplicate": columns_to_duplicate,
+            "columns_mapping": columns_mapping,
+            "prefix": prefix,
+            "suffix": suffix,
+            "columns_final_mapping": columns_final_mapping,
         }
     }
 
@@ -96,25 +93,14 @@ def column_duplicatable(columns_to_bind: str) -> Callable:
     def _decorator(child: toolz.curry) -> Callable:
         mixin = feature_duplicator
 
-        def _init(
-            *args: List[Any],
-            **kwargs: Dict[str, Any]
-        ) -> Union[Callable, LearnerReturnType]:
+        def _init(*args: List[Any], **kwargs: Dict[str, Any]) -> Union[Callable, LearnerReturnType]:
             mixin_spec = inspect.getfullargspec(mixin)
             mixin_named_args = set(mixin_spec.args) | set(mixin_spec.kwonlyargs)
-            mixin_kwargs = {
-                key: value
-                for key, value in kwargs.items()
-                if key in mixin_named_args
-            }
+            mixin_kwargs = {key: value for key, value in kwargs.items() if key in mixin_named_args}
 
             child_spec = inspect.getfullargspec(child)
             child_named_args = set(child_spec.args) | set(child_spec.kwonlyargs)
-            child_kwargs: Dict[str, Any] = {
-                key: value
-                for key, value in kwargs.items()
-                if key in child_named_args
-            }
+            child_kwargs: Dict[str, Any] = {key: value for key, value in kwargs.items() if key in child_named_args}
 
             child_arg_names = list(inspect.signature(child).parameters.keys())
             columns_to_bind_idx = child_arg_names.index(columns_to_bind)
@@ -123,30 +109,19 @@ def column_duplicatable(columns_to_bind: str) -> Callable:
 
             if curry_is_ready:
                 columns_to_duplicate = (
-                    kwargs[columns_to_bind]
-                    if columns_to_bind in kwargs
-                    else args[columns_to_bind_idx]
+                    kwargs[columns_to_bind] if columns_to_bind in kwargs else args[columns_to_bind_idx]
                 )
                 mixin_fn, mixin_df, mixin_log = mixin(
-                    args[0],
-                    **mixin_kwargs,
-                    columns_to_duplicate=columns_to_duplicate)
-                child_fn, child_df, child_log = child(
-                    mixin_df,
-                    *args[1:],
-                    **child_kwargs)
-
-                return (
-                    toolz.compose(child_fn, mixin_fn),
-                    child_df,
-                    {**mixin_log, **child_log}
+                    args[0], **mixin_kwargs, columns_to_duplicate=columns_to_duplicate
                 )
+                child_fn, child_df, child_log = child(mixin_df, *args[1:], **child_kwargs)
+
+                return (toolz.compose(child_fn, mixin_fn), child_df, {**mixin_log, **child_log})
 
             else:
                 return functools.update_wrapper(
-                    functools.partial(
-                        _init, *args, **kwargs),
-                    child(*args[1:], **child_kwargs))
+                    functools.partial(_init, *args, **kwargs), child(*args[1:], **child_kwargs)
+                )
 
         callable_fn = functools.update_wrapper(_init, child)
 

--- a/src/fklearn/preprocessing/splitting.py
+++ b/src/fklearn/preprocessing/splitting.py
@@ -10,12 +10,14 @@ from fklearn.types import DateType
 
 
 @curry
-def time_split_dataset(dataset: pd.DataFrame,
-                       train_start_date: DateType,
-                       train_end_date: DateType,
-                       holdout_end_date: DateType,
-                       time_column: str,
-                       holdout_start_date: DateType = None) -> Tuple[pd.DataFrame, pd.DataFrame]:
+def time_split_dataset(
+    dataset: pd.DataFrame,
+    train_start_date: DateType,
+    train_end_date: DateType,
+    holdout_end_date: DateType,
+    time_column: str,
+    holdout_start_date: DateType = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Splits temporal data into a training and testing datasets such that
     all training data comes before the testings one.
@@ -59,26 +61,26 @@ def time_split_dataset(dataset: pd.DataFrame,
 
     holdout_start_date = holdout_start_date if holdout_start_date else train_end_date
 
-    train_set = dataset[
-        (dataset[time_column] >= train_start_date) & (dataset[time_column] < train_end_date)]
+    train_set = dataset[(dataset[time_column] >= train_start_date) & (dataset[time_column] < train_end_date)]
 
-    test_set = dataset[
-        (dataset[time_column] >= holdout_start_date) & (dataset[time_column] < holdout_end_date)]
+    test_set = dataset[(dataset[time_column] >= holdout_start_date) & (dataset[time_column] < holdout_end_date)]
 
     return train_set, test_set
 
 
 @curry
-def space_time_split_dataset(dataset: pd.DataFrame,
-                             train_start_date: DateType,
-                             train_end_date: DateType,
-                             holdout_end_date: DateType,
-                             split_seed: int,
-                             space_holdout_percentage: float,
-                             space_column: str,
-                             time_column: str,
-                             holdout_space: np.ndarray = None,
-                             holdout_start_date: DateType = None) -> Tuple[pd.DataFrame, ...]:
+def space_time_split_dataset(
+    dataset: pd.DataFrame,
+    train_start_date: DateType,
+    train_end_date: DateType,
+    holdout_end_date: DateType,
+    split_seed: int,
+    space_holdout_percentage: float,
+    space_column: str,
+    time_column: str,
+    holdout_space: np.ndarray = None,
+    holdout_start_date: DateType = None,
+) -> Tuple[pd.DataFrame, ...]:
     """
     Splits panel data using both ID and Time columns, resulting in four datasets
 
@@ -156,9 +158,9 @@ def space_time_split_dataset(dataset: pd.DataFrame,
         train_period_space = np.sort(all_space_in_time)
 
         # randomly sample accounts from the train period to hold out
-        partial_holdout_space = state.choice(train_period_space,
-                                             int(space_holdout_percentage * len(train_period_space)),
-                                             replace=False)
+        partial_holdout_space = state.choice(
+            train_period_space, int(space_holdout_percentage * len(train_period_space)), replace=False
+        )
 
         in_space = pd.Index(all_space_in_time).difference(pd.Index(partial_holdout_space)).values
 
@@ -176,39 +178,40 @@ def space_time_split_dataset(dataset: pd.DataFrame,
 
 
 @curry
-def stratified_split_dataset(dataset: pd.DataFrame, target_column: str, test_size: float,
-                             random_state: Optional[int] = None) -> Tuple[pd.DataFrame, pd.DataFrame]:
+def stratified_split_dataset(
+    dataset: pd.DataFrame, target_column: str, test_size: float, random_state: Optional[int] = None
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
-        Splits data into a training and testing datasets such that
-        they maintain the same class ratio of the original dataset.
+    Splits data into a training and testing datasets such that
+    they maintain the same class ratio of the original dataset.
 
-        Parameters
-        ----------
-        dataset : pandas.DataFrame
-            A Pandas' DataFrame with the target column.
-            The model will be trained to predict the target column
-            from the features.
+    Parameters
+    ----------
+    dataset : pandas.DataFrame
+        A Pandas' DataFrame with the target column.
+        The model will be trained to predict the target column
+        from the features.
 
-        target_column : str
-            The name of the target column of `dataset`.
+    target_column : str
+        The name of the target column of `dataset`.
 
-        test_size : float
-            Represent the proportion of the dataset to include in the test split.
-            should be between 0.0 and 1.0.
+    test_size : float
+        Represent the proportion of the dataset to include in the test split.
+        should be between 0.0 and 1.0.
 
-        random_state : int or None, optional (default=None)
-            If int, random_state is the seed used by the random number generator;
-            If None, the random number generator is the RandomState instance used
-            by `np.random`.
+    random_state : int or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
 
-        Returns
-        ----------
-        train_set : pandas.DataFrame
-            The train dataset sampled from the full dataset.
+    Returns
+    ----------
+    train_set : pandas.DataFrame
+        The train dataset sampled from the full dataset.
 
-        test_set : pandas.DataFrame
-            The test dataset sampled from the full dataset.
-        """
+    test_set : pandas.DataFrame
+        The test dataset sampled from the full dataset.
+    """
     train_placeholder = np.zeros(len(dataset))
     target = dataset[target_column]
 

--- a/src/fklearn/training/imputation.py
+++ b/src/fklearn/training/imputation.py
@@ -10,11 +10,13 @@ from fklearn.training.utils import log_learner_time
 
 
 @curry
-@log_learner_time(learner_name='imputer')
-def imputer(df: pd.DataFrame,
-            columns_to_impute: List[str],
-            impute_strategy: str = 'median',
-            placeholder_value: Optional[Any] = None) -> LearnerReturnType:
+@log_learner_time(learner_name="imputer")
+def imputer(
+    df: pd.DataFrame,
+    columns_to_impute: List[str],
+    impute_strategy: str = "median",
+    placeholder_value: Optional[Any] = None,
+) -> LearnerReturnType:
     """
     Fits a missing value imputer to the dataset.
 
@@ -46,7 +48,8 @@ def imputer(df: pd.DataFrame,
         columns_imputable = mask_feat_is_na[~mask_feat_is_na].index.values
 
         fill_fn, _, fill_logs = placeholder_imputer(
-            df, columns_to_impute=columns_to_fill, placeholder_value=placeholder_value)
+            df, columns_to_impute=columns_to_fill, placeholder_value=placeholder_value
+        )
     else:
         columns_to_fill = list()
         columns_imputable = columns_to_impute
@@ -58,22 +61,22 @@ def imputer(df: pd.DataFrame,
 
     def p(new_data_set: pd.DataFrame) -> pd.DataFrame:
         new_data = imp.transform(new_data_set[columns_imputable])
-        new_cols = pd.DataFrame(data=new_data, columns=columns_imputable).to_dict('list')
+        new_cols = pd.DataFrame(data=new_data, columns=columns_imputable).to_dict("list")
         return fill_fn(new_data_set.assign(**new_cols))
 
     p.__doc__ = learner_pred_fn_docstring("imputer")
 
     log = {
-        'imputer': {
-            'impute_strategy': impute_strategy,
-            'placeholder_value': placeholder_value,
-            'columns_to_impute': columns_to_impute,
-            'columns_to_fill': columns_to_fill,
-            'columns_imputable': columns_imputable,
-            'training_proportion_of_nulls': df[columns_to_impute].isnull().mean(axis=0).to_dict(),
-            'statistics': imp.statistics_,
-            'placeholder_imputer_fn': fill_fn,
-            'placeholder_imputer_logs': fill_logs,
+        "imputer": {
+            "impute_strategy": impute_strategy,
+            "placeholder_value": placeholder_value,
+            "columns_to_impute": columns_to_impute,
+            "columns_to_fill": columns_to_fill,
+            "columns_imputable": columns_imputable,
+            "training_proportion_of_nulls": df[columns_to_impute].isnull().mean(axis=0).to_dict(),
+            "statistics": imp.statistics_,
+            "placeholder_imputer_fn": fill_fn,
+            "placeholder_imputer_logs": fill_logs,
         }
     }
 
@@ -84,10 +87,10 @@ imputer.__doc__ += learner_return_docstring("SimpleImputer")
 
 
 @curry
-@log_learner_time(learner_name='placeholder_imputer')
-def placeholder_imputer(df: pd.DataFrame,
-                        columns_to_impute: List[str],
-                        placeholder_value: Any = -999) -> LearnerReturnType:
+@log_learner_time(learner_name="placeholder_imputer")
+def placeholder_imputer(
+    df: pd.DataFrame, columns_to_impute: List[str], placeholder_value: Any = -999
+) -> LearnerReturnType:
     """
     Fills missing values with a fixed value.
 
@@ -106,16 +109,16 @@ def placeholder_imputer(df: pd.DataFrame,
     """
 
     def p(new_data_set: pd.DataFrame) -> pd.DataFrame:
-        new_cols = new_data_set[columns_to_impute].fillna(placeholder_value).to_dict('list')
+        new_cols = new_data_set[columns_to_impute].fillna(placeholder_value).to_dict("list")
         return new_data_set.assign(**new_cols)
 
     p.__doc__ = learner_pred_fn_docstring("placeholder_imputer")
 
     log = {
-        'placeholder_imputer': {
-            'columns_to_impute': columns_to_impute,
-            'training_proportion_of_nulls': df[columns_to_impute].isnull().mean(axis=0).to_dict(),
-            'placeholder_value': placeholder_value
+        "placeholder_imputer": {
+            "columns_to_impute": columns_to_impute,
+            "training_proportion_of_nulls": df[columns_to_impute].isnull().mean(axis=0).to_dict(),
+            "placeholder_value": placeholder_value,
         }
     }
 

--- a/src/fklearn/training/pipeline.py
+++ b/src/fklearn/training/pipeline.py
@@ -44,20 +44,24 @@ def build_pipeline(*learners: LearnerFnType, has_repeated_learners: bool = False
     """
 
     def _has_one_unfilled_arg(learner: LearnerFnType) -> None:
-        no_default_list = [p for p, a in signature(learner).parameters.items() if a.default == '__no__default__']
+        no_default_list = [p for p, a in signature(learner).parameters.items() if a.default == "__no__default__"]
         if len(no_default_list) > 1:
-            raise ValueError("Learner {0} has more than one unfilled argument: {1}\n"
-                             "Make sure all learners are curried properly and only require one argument,"
-                             " which is the dataset (usually `df`)."
-                             .format(learner.__name__, ', '.join(no_default_list)))
+            raise ValueError(
+                "Learner {0} has more than one unfilled argument: {1}\n"
+                "Make sure all learners are curried properly and only require one argument,"
+                " which is the dataset (usually `df`).".format(learner.__name__, ", ".join(no_default_list))
+            )
 
     def _no_variable_args(learner: LearnerFnType, predict_fn: PredictFnType) -> None:
         invalid_parameter_kinds = (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD)
         var_args = [p for p, a in signature(predict_fn).parameters.items() if a.kind in invalid_parameter_kinds]
         if len(var_args) != 0:
-            raise ValueError("Predict function of learner {0} contains variable length arguments: {1}\n"
-                             "Make sure no predict function uses arguments like *args or **kwargs."
-                             .format(learner.__name__, ', '.join(var_args)))
+            raise ValueError(
+                "Predict function of learner {0} contains variable length arguments: {1}\n"
+                "Make sure no predict function uses arguments like *args or **kwargs.".format(
+                    learner.__name__, ", ".join(var_args)
+                )
+            )
 
     # Check for unfilled arguments of learners
     for learner in learners:
@@ -99,10 +103,12 @@ def build_pipeline(*learners: LearnerFnType, has_repeated_learners: bool = False
 
         serialisation_logs = {k: v if has_repeated_learners else v[-1] for k, v in serialisation.items()}
 
-        merged_logs["__fkml__"] = {"pipeline": pipeline,
-                                   "output_columns": list(current_data.columns),
-                                   "features": features,
-                                   "learners": {**serialisation_logs}}
+        merged_logs["__fkml__"] = {
+            "pipeline": pipeline,
+            "output_columns": list(current_data.columns),
+            "features": features,
+            "learners": {**serialisation_logs},
+        }
 
         return predict_fn, current_data, merged_logs
 

--- a/src/fklearn/training/regression.py
+++ b/src/fklearn/training/regression.py
@@ -13,14 +13,16 @@ from fklearn.training.utils import log_learner_time, expand_features_encoded
 
 
 @curry
-@log_learner_time(learner_name='linear_regression_learner')
-def linear_regression_learner(df: pd.DataFrame,
-                              features: List[str],
-                              target: str,
-                              params: Dict[str, Any] = None,
-                              prediction_column: str = "prediction",
-                              weight_column: str = None,
-                              encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="linear_regression_learner")
+def linear_regression_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    weight_column: str = None,
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an linear regressor to the dataset. Return the predict function
     for the model and the predictions for the input dataset.
@@ -70,16 +72,19 @@ def linear_regression_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("linear_regression_learner")
 
-    log = {'linear_regression_learner': {
-        'features': features,
-        'target': target,
-        'parameters': params,
-        'prediction_column': prediction_column,
-        'package': "sklearn",
-        'package_version': sk_version,
-        'feature_importance': dict(zip(features, regr.coef_.flatten())),
-        'training_samples': len(df)},
-        'object': regr}
+    log = {
+        "linear_regression_learner": {
+            "features": features,
+            "target": target,
+            "parameters": params,
+            "prediction_column": prediction_column,
+            "package": "sklearn",
+            "package_version": sk_version,
+            "feature_importance": dict(zip(features, regr.coef_.flatten())),
+            "training_samples": len(df),
+        },
+        "object": regr,
+    }
 
     return p, p(df), log
 
@@ -88,16 +93,18 @@ linear_regression_learner.__doc__ += learner_return_docstring("Linear Regression
 
 
 @curry
-@log_learner_time(learner_name='xgb_regression_learner')
-def xgb_regression_learner(df: pd.DataFrame,
-                           features: List[str],
-                           target: str,
-                           learning_rate: float = 0.1,
-                           num_estimators: int = 100,
-                           extra_params: Dict[str, Any] = None,
-                           prediction_column: str = "prediction",
-                           weight_column: str = None,
-                           encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="xgb_regression_learner")
+def xgb_regression_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    learning_rate: float = 0.1,
+    num_estimators: int = 100,
+    extra_params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    weight_column: str = None,
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an XGBoost regressor to the dataset. It first generates a DMatrix
     with the specified features and labels from `df`. Then it fits a XGBoost
@@ -155,7 +162,7 @@ def xgb_regression_learner(df: pd.DataFrame,
     weights = df[weight_column].values if weight_column else None
     params = extra_params if extra_params else {}
     params = assoc(params, "eta", learning_rate)
-    params = params if "objective" in params else assoc(params, "objective", 'reg:linear')
+    params = params if "objective" in params else assoc(params, "objective", "reg:linear")
 
     features = features if not encode_extra_cols else expand_features_encoded(df, features)
 
@@ -169,12 +176,15 @@ def xgb_regression_learner(df: pd.DataFrame,
 
         if apply_shap:
             import shap
+
             explainer = shap.TreeExplainer(bst)
             shap_values = list(explainer.shap_values(new_df[features]))
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+            shap_output = {
+                "shap_values": shap_values,
+                "shap_expected_value": np.repeat(shap_expected_value, len(shap_values)),
+            }
 
             col_dict = merge(col_dict, shap_output)
 
@@ -182,16 +192,19 @@ def xgb_regression_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("xgb_regression_learner", shap=True)
 
-    log = {'xgb_regression_learner': {
-        'features': features,
-        'target': target,
-        'prediction_column': prediction_column,
-        'package': "xgboost",
-        'package_version': xgb.__version__,
-        'parameters': assoc(params, "num_estimators", num_estimators),
-        'feature_importance': bst.get_score(),
-        'training_samples': len(df)},
-        'object': bst}
+    log = {
+        "xgb_regression_learner": {
+            "features": features,
+            "target": target,
+            "prediction_column": prediction_column,
+            "package": "xgboost",
+            "package_version": xgb.__version__,
+            "parameters": assoc(params, "num_estimators", num_estimators),
+            "feature_importance": bst.get_score(),
+            "training_samples": len(df),
+        },
+        "object": bst,
+    }
 
     return p, p(df), log
 
@@ -200,15 +213,17 @@ xgb_regression_learner.__doc__ += learner_return_docstring("XGboost Regressor")
 
 
 @curry
-@log_learner_time(learner_name='catboost_regressor_learner')
-def catboost_regressor_learner(df: pd.DataFrame,
-                               features: List[str],
-                               target: str,
-                               learning_rate: float = 0.1,
-                               num_estimators: int = 100,
-                               extra_params: Dict[str, Any] = None,
-                               prediction_column: str = "prediction",
-                               weight_column: str = None) -> LearnerReturnType:
+@log_learner_time(learner_name="catboost_regressor_learner")
+def catboost_regressor_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    learning_rate: float = 0.1,
+    num_estimators: int = 100,
+    extra_params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    weight_column: str = None,
+) -> LearnerReturnType:
     """
     Fits an CatBoost regressor to the dataset. It first generates a Pool
     with the specified features and labels from `df`. Then it fits a CatBoost
@@ -274,12 +289,15 @@ def catboost_regressor_learner(df: pd.DataFrame,
 
         if apply_shap:
             import shap
+
             explainer = shap.TreeExplainer(cbr)
             shap_values = list(explainer.shap_values(new_df[features]))
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+            shap_output = {
+                "shap_values": shap_values,
+                "shap_expected_value": np.repeat(shap_expected_value, len(shap_values)),
+            }
 
             col_dict = merge(col_dict, shap_output)
 
@@ -287,16 +305,19 @@ def catboost_regressor_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("CatBoostRegressor", shap=False)
 
-    log = {'catboost_regression_learner': {
-        'features': features,
-        'target': target,
-        'prediction_column': prediction_column,
-        'package': "catboost",
-        'package_version': catboost.__version__,
-        'parameters': assoc(params, "num_estimators", num_estimators),
-        'feature_importance': cbr.feature_importances_,
-        'training_samples': len(df)},
-        'object': cbr}
+    log = {
+        "catboost_regression_learner": {
+            "features": features,
+            "target": target,
+            "prediction_column": prediction_column,
+            "package": "catboost",
+            "package_version": catboost.__version__,
+            "parameters": assoc(params, "num_estimators", num_estimators),
+            "feature_importance": cbr.feature_importances_,
+            "training_samples": len(df),
+        },
+        "object": cbr,
+    }
 
     return p, p(df), log
 
@@ -305,17 +326,19 @@ catboost_regressor_learner.__doc__ += learner_return_docstring("CatBoostRegresso
 
 
 @curry
-@log_learner_time(learner_name='gp_regression_learner')
-def gp_regression_learner(df: pd.DataFrame,
-                          features: List[str],
-                          target: str,
-                          kernel: kernels.Kernel = None,
-                          alpha: float = 0.1,
-                          extra_variance: Union[str, float] = "fit",
-                          return_std: bool = False,
-                          extra_params: Dict[str, Any] = None,
-                          prediction_column: str = "prediction",
-                          encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="gp_regression_learner")
+def gp_regression_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    kernel: kernels.Kernel = None,
+    alpha: float = 0.1,
+    extra_variance: Union[str, float] = "fit",
+    return_std: bool = False,
+    extra_params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an gaussian process regressor to the dataset.
 
@@ -367,8 +390,8 @@ def gp_regression_learner(df: pd.DataFrame,
 
     params = extra_params if extra_params else {}
 
-    params['alpha'] = alpha
-    params['kernel'] = kernel
+    params["alpha"] = alpha
+    params["kernel"] = kernel
 
     features = features if not encode_extra_cols else expand_features_encoded(df, features)
 
@@ -387,16 +410,18 @@ def gp_regression_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("gp_regression_learner")
 
-    log = {'gp_regression_learner': {
-        'features': features,
-        'target': target,
-        'parameters': merge(params, {'extra_variance': extra_variance,
-                                     'return_std': return_std}),
-        'prediction_column': prediction_column,
-        'package': "sklearn",
-        'package_version': sk_version,
-        'training_samples': len(df)},
-        'object': gp}
+    log = {
+        "gp_regression_learner": {
+            "features": features,
+            "target": target,
+            "parameters": merge(params, {"extra_variance": extra_variance, "return_std": return_std}),
+            "prediction_column": prediction_column,
+            "package": "sklearn",
+            "package_version": sk_version,
+            "training_samples": len(df),
+        },
+        "object": gp,
+    }
 
     return p, p(df), log
 
@@ -405,16 +430,18 @@ gp_regression_learner.__doc__ += learner_return_docstring("Gaussian Process Regr
 
 
 @curry
-@log_learner_time(learner_name='lgbm_regression_learner')
-def lgbm_regression_learner(df: pd.DataFrame,
-                            features: List[str],
-                            target: str,
-                            learning_rate: float = 0.1,
-                            num_estimators: int = 100,
-                            extra_params: Dict[str, Any] = None,
-                            prediction_column: str = "prediction",
-                            weight_column: str = None,
-                            encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="lgbm_regression_learner")
+def lgbm_regression_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    learning_rate: float = 0.1,
+    num_estimators: int = 100,
+    extra_params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    weight_column: str = None,
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an LGBM regressor to the dataset.
 
@@ -472,14 +499,15 @@ def lgbm_regression_learner(df: pd.DataFrame,
 
     params = extra_params if extra_params else {}
     params = assoc(params, "eta", learning_rate)
-    params = params if "objective" in params else assoc(params, "objective", 'regression')
+    params = params if "objective" in params else assoc(params, "objective", "regression")
 
     weights = df[weight_column].values if weight_column else None
 
     features = features if not encode_extra_cols else expand_features_encoded(df, features)
 
-    dtrain = lgbm.Dataset(df[features].values, label=df[target], feature_name=list(map(str, features)), weight=weights,
-                          silent=True)
+    dtrain = lgbm.Dataset(
+        df[features].values, label=df[target], feature_name=list(map(str, features)), weight=weights, silent=True
+    )
 
     bst = lgbm.train(params, dtrain, num_estimators)
 
@@ -488,12 +516,15 @@ def lgbm_regression_learner(df: pd.DataFrame,
 
         if apply_shap:
             import shap
+
             explainer = shap.TreeExplainer(bst)
             shap_values = list(explainer.shap_values(new_df[features]))
             shap_expected_value = explainer.expected_value
 
-            shap_output = {"shap_values": shap_values,
-                           "shap_expected_value": np.repeat(shap_expected_value, len(shap_values))}
+            shap_output = {
+                "shap_values": shap_values,
+                "shap_expected_value": np.repeat(shap_expected_value, len(shap_values)),
+            }
 
             col_dict = merge(col_dict, shap_output)
 
@@ -501,16 +532,19 @@ def lgbm_regression_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("lgbm_regression_learner", shap=True)
 
-    log = {'lgbm_regression_learner': {
-        'features': features,
-        'target': target,
-        'prediction_column': prediction_column,
-        'package': "lightgbm",
-        'package_version': lgbm.__version__,
-        'parameters': assoc(params, "num_estimators", num_estimators),
-        'feature_importance': dict(zip(features, bst.feature_importance().tolist())),
-        'training_samples': len(df)},
-        'object': bst}
+    log = {
+        "lgbm_regression_learner": {
+            "features": features,
+            "target": target,
+            "prediction_column": prediction_column,
+            "package": "lightgbm",
+            "package_version": lgbm.__version__,
+            "parameters": assoc(params, "num_estimators", num_estimators),
+            "feature_importance": dict(zip(features, bst.feature_importance().tolist())),
+            "training_samples": len(df),
+        },
+        "object": bst,
+    }
 
     return p, p(df), log
 
@@ -519,14 +553,16 @@ lgbm_regression_learner.__doc__ += learner_return_docstring("LGBM Regressor")
 
 
 @curry
-@log_learner_time(learner_name='custom_supervised_model_learner')
-def custom_supervised_model_learner(df: pd.DataFrame,
-                                    features: List[str],
-                                    target: str,
-                                    model: Any,
-                                    supervised_type: str,
-                                    log: Dict[str, Dict],
-                                    prediction_column: str = "prediction") -> LearnerReturnType:
+@log_learner_time(learner_name="custom_supervised_model_learner")
+def custom_supervised_model_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    model: Any,
+    supervised_type: str,
+    log: Dict[str, Dict],
+    prediction_column: str = "prediction",
+) -> LearnerReturnType:
     """
     Fits a custom model to the dataset.
     Return the predict function, the predictions for the input dataset and a log describing the model.
@@ -567,25 +603,25 @@ def custom_supervised_model_learner(df: pd.DataFrame,
     """
 
     if len(log) != 1:
-        raise ValueError("\'log\' dictionary must start with model name")
-    if supervised_type not in ('classification', 'regression'):
-        raise TypeError("supervised_type options are: \'classification\' or \'regression\'")
-    if not hasattr(model, 'fit'):
-        raise AttributeError("\'model\' object must have \'fit\' attribute")
-    if supervised_type == 'classification' and not hasattr(model, 'predict_proba'):
-        raise AttributeError("\'model\' object for classification must have \'predict_proba\' attribute")
-    if supervised_type == 'regression' and not hasattr(model, 'predict'):
-        raise AttributeError("\'model\' object for regression must have \'predict\' attribute")
+        raise ValueError("'log' dictionary must start with model name")
+    if supervised_type not in ("classification", "regression"):
+        raise TypeError("supervised_type options are: 'classification' or 'regression'")
+    if not hasattr(model, "fit"):
+        raise AttributeError("'model' object must have 'fit' attribute")
+    if supervised_type == "classification" and not hasattr(model, "predict_proba"):
+        raise AttributeError("'model' object for classification must have 'predict_proba' attribute")
+    if supervised_type == "regression" and not hasattr(model, "predict"):
+        raise AttributeError("'model' object for regression must have 'predict' attribute")
 
     model.fit(df[features].values, df[target].values)
 
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
-        if supervised_type == 'classification':
+        if supervised_type == "classification":
             pred = model.predict_proba(new_df[features].values)
             col_dict = {}
             for (key, value) in enumerate(pred.T):
                 col_dict.update({prediction_column + "_" + str(key): value})
-        elif supervised_type == 'regression':
+        elif supervised_type == "regression":
             col_dict = {prediction_column: model.predict(new_df[features].values)}
 
         return new_df.assign(**col_dict)
@@ -601,14 +637,16 @@ custom_supervised_model_learner.__doc__ += learner_return_docstring("Custom Supe
 
 
 @curry
-@log_learner_time(learner_name='elasticnet_regression_learner')
-def elasticnet_regression_learner(df: pd.DataFrame,
-                                  features: List[str],
-                                  target: str,
-                                  params: Dict[str, Any] = None,
-                                  prediction_column: str = "prediction",
-                                  weight_column: str = None,
-                                  encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="elasticnet_regression_learner")
+def elasticnet_regression_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    target: str,
+    params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    weight_column: str = None,
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an elastic net regressor to the dataset. Return the predict function
     for the model and the predictions for the input dataset.
@@ -658,16 +696,19 @@ def elasticnet_regression_learner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("elasticnet_regression_learner")
 
-    log = {'elasticnet_regression_learner': {
-        'features': features,
-        'target': target,
-        'parameters': params,
-        'prediction_column': prediction_column,
-        'package': "sklearn",
-        'package_version': sk_version,
-        'feature_importance': dict(zip(features, regr.coef_.flatten())),
-        'training_samples': len(df)},
-        'object': regr}
+    log = {
+        "elasticnet_regression_learner": {
+            "features": features,
+            "target": target,
+            "parameters": params,
+            "prediction_column": prediction_column,
+            "package": "sklearn",
+            "package_version": sk_version,
+            "feature_importance": dict(zip(features, regr.coef_.flatten())),
+            "training_samples": len(df),
+        },
+        "object": regr,
+    }
 
     return p, p(df), log
 

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -739,7 +739,7 @@ def onehot_categorizer(
         make_dummies = lambda col: dict(
             map(
                 lambda categ: ("fklearn_feat__" + col + "==" + str(categ), (new_df[col] == categ).astype(int)),
-                vec[col][int(drop_first_column) :],
+                vec[col][int(drop_first_column):],
             )
         )
 

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -13,10 +13,8 @@ from fklearn.preprocessing.schema import column_duplicatable
 
 
 @curry
-@log_learner_time(learner_name='selector')
-def selector(df: pd.DataFrame,
-             training_columns: List[str],
-             predict_columns: List[str] = None) -> LearnerReturnType:
+@log_learner_time(learner_name="selector")
+def selector(df: pd.DataFrame, training_columns: List[str], predict_columns: List[str] = None) -> LearnerReturnType:
     """
     Filters a DataFrames by selecting only the desired columns.
 
@@ -41,10 +39,13 @@ def selector(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("selector")
 
-    log = {'selector': {
-        'training_columns': training_columns,
-        'predict_columns': predict_columns,
-        'transformed_column': list(set(training_columns).union(predict_columns))}}
+    log = {
+        "selector": {
+            "training_columns": training_columns,
+            "predict_columns": predict_columns,
+            "transformed_column": list(set(training_columns).union(predict_columns)),
+        }
+    }
 
     return p, df[training_columns], log
 
@@ -52,12 +53,10 @@ def selector(df: pd.DataFrame,
 selector.__doc__ += learner_return_docstring("Selector")
 
 
-@column_duplicatable('columns_to_cap')
+@column_duplicatable("columns_to_cap")
 @curry
-@log_learner_time(learner_name='capper')
-def capper(df: pd.DataFrame,
-           columns_to_cap: List[str],
-           precomputed_caps: Dict[str, float] = None) -> LearnerReturnType:
+@log_learner_time(learner_name="capper")
+def capper(df: pd.DataFrame, columns_to_cap: List[str], precomputed_caps: Dict[str, float] = None) -> LearnerReturnType:
     """
     Learns the maximum value for each of the `columns_to_cap`
     and used that as the cap for those columns. If precomputed caps
@@ -88,10 +87,7 @@ def capper(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("capper")
 
-    log = {'capper': {
-        'caps': caps,
-        'transformed_column': columns_to_cap,
-        'precomputed_caps': precomputed_caps}}
+    log = {"capper": {"caps": caps, "transformed_column": columns_to_cap, "precomputed_caps": precomputed_caps}}
 
     return p, p(df), log
 
@@ -99,12 +95,12 @@ def capper(df: pd.DataFrame,
 capper.__doc__ += learner_return_docstring("Capper")
 
 
-@column_duplicatable('columns_to_floor')
+@column_duplicatable("columns_to_floor")
 @curry
-@log_learner_time(learner_name='floorer')
-def floorer(df: pd.DataFrame,
-            columns_to_floor: List[str],
-            precomputed_floors: Dict[str, float] = None) -> LearnerReturnType:
+@log_learner_time(learner_name="floorer")
+def floorer(
+    df: pd.DataFrame, columns_to_floor: List[str], precomputed_floors: Dict[str, float] = None
+) -> LearnerReturnType:
     """
     Learns the minimum value for each of the `columns_to_floor`
     and used that as the floot for those columns. If precomputed floors
@@ -136,10 +132,9 @@ def floorer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("floorer")
 
-    log = {'floorer': {
-        'floors': floors,
-        'transformed_column': columns_to_floor,
-        'precomputed_floors': precomputed_floors}}
+    log = {
+        "floorer": {"floors": floors, "transformed_column": columns_to_floor, "precomputed_floors": precomputed_floors}
+    }
 
     return p, p(df), log
 
@@ -148,12 +143,14 @@ floorer.__doc__ += learner_return_docstring("Floorer")
 
 
 @curry
-@log_learner_time(learner_name='ecdfer')
-def ecdfer(df: pd.DataFrame,
-           ascending: bool = True,
-           prediction_column: str = "prediction",
-           ecdf_column: str = "prediction_ecdf",
-           max_range: int = 1000) -> LearnerReturnType:
+@log_learner_time(learner_name="ecdfer")
+def ecdfer(
+    df: pd.DataFrame,
+    ascending: bool = True,
+    prediction_column: str = "prediction",
+    ecdf_column: str = "prediction_ecdf",
+    max_range: int = 1000,
+) -> LearnerReturnType:
     """
     Learns an Empirical Cumulative Distribution Function from the specified column
     in the input DataFrame. It is usually used in the prediction column to convert
@@ -194,11 +191,14 @@ def ecdfer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("ecdefer")
 
-    log = {'ecdfer': {
-        'nobs': len(values),
-        'prediction_column': prediction_column,
-        'ascending': ascending,
-        'transformed_column': [ecdf_column]}}
+    log = {
+        "ecdfer": {
+            "nobs": len(values),
+            "prediction_column": prediction_column,
+            "ascending": ascending,
+            "transformed_column": [ecdf_column],
+        }
+    }
 
     return p, p(df), log
 
@@ -207,13 +207,15 @@ ecdfer.__doc__ += learner_return_docstring("ECDFer")
 
 
 @curry
-@log_learner_time(learner_name='discrete_ecdfer')
-def discrete_ecdfer(df: pd.DataFrame,
-                    ascending: bool = True,
-                    prediction_column: str = "prediction",
-                    ecdf_column: str = "prediction_ecdf",
-                    max_range: int = 1000,
-                    round_method: Callable = int) -> LearnerReturnType:
+@log_learner_time(learner_name="discrete_ecdfer")
+def discrete_ecdfer(
+    df: pd.DataFrame,
+    ascending: bool = True,
+    prediction_column: str = "prediction",
+    ecdf_column: str = "prediction_ecdf",
+    max_range: int = 1000,
+    round_method: Callable = int,
+) -> LearnerReturnType:
     """
     Learns an Empirical Cumulative Distribution Function from the specified column
     in the input DataFrame. It is usually used in the prediction column to convert
@@ -253,8 +255,8 @@ def discrete_ecdfer(df: pd.DataFrame,
     ecdf = ed.ECDF(values)
 
     df_ecdf = pd.DataFrame()
-    df_ecdf['x'] = ecdf.x
-    df_ecdf['y'] = pd.Series(base + sign * max_range * ecdf.y).apply(round_method)
+    df_ecdf["x"] = ecdf.x
+    df_ecdf["y"] = pd.Series(base + sign * max_range * ecdf.y).apply(round_method)
 
     boundaries = df_ecdf.groupby("y").agg((min, max))["x"]["min"].reset_index()
 
@@ -262,13 +264,16 @@ def discrete_ecdfer(df: pd.DataFrame,
     x = boundaries["min"]
     side = ecdf.side
 
-    log = {'discrete_ecdfer': {
-        'map': dict(zip(x, y)),
-        'round_method': round_method,
-        'nobs': len(values),
-        'prediction_column': prediction_column,
-        'ascending': ascending,
-        'transformed_column': [ecdf_column]}}
+    log = {
+        "discrete_ecdfer": {
+            "map": dict(zip(x, y)),
+            "round_method": round_method,
+            "nobs": len(values),
+            "prediction_column": prediction_column,
+            "ascending": ascending,
+            "transformed_column": [ecdf_column],
+        }
+    }
 
     del ecdf
     del values
@@ -289,10 +294,9 @@ discrete_ecdfer.__doc__ += learner_return_docstring("Discrete ECDFer")
 
 
 @curry
-def prediction_ranger(df: pd.DataFrame,
-                      prediction_min: float,
-                      prediction_max: float,
-                      prediction_column: str = "prediction") -> LearnerReturnType:
+def prediction_ranger(
+    df: pd.DataFrame, prediction_min: float, prediction_max: float, prediction_column: str = "prediction"
+) -> LearnerReturnType:
     """
     Caps and floors the specified prediction column to a set range.
 
@@ -318,10 +322,13 @@ def prediction_ranger(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("prediction_ranger")
 
-    log = {'prediction_ranger': {
-        'prediction_min': prediction_min,
-        'prediction_max': prediction_max,
-        'transformed_column': [prediction_column]}}
+    log = {
+        "prediction_ranger": {
+            "prediction_min": prediction_min,
+            "prediction_max": prediction_max,
+            "transformed_column": [prediction_column],
+        }
+    }
 
     return p, p(df), log
 
@@ -329,10 +336,7 @@ def prediction_ranger(df: pd.DataFrame,
 prediction_ranger.__doc__ += learner_return_docstring("Prediction Ranger")
 
 
-def apply_replacements(df: pd.DataFrame,
-                       columns: List[str],
-                       vec: Dict[str, Dict],
-                       replace_unseen: Any) -> pd.DataFrame:
+def apply_replacements(df: pd.DataFrame, columns: List[str], vec: Dict[str, Dict], replace_unseen: Any) -> pd.DataFrame:
     """
     Base function to apply the replacements values found on the
     "vec" vectors into the df DataFrame.
@@ -354,20 +358,19 @@ def apply_replacements(df: pd.DataFrame,
         Default value to replace when original value is not present in the `vec` dict for the feature
 
     """
-    column_categorizer = lambda col: df[col].apply(lambda x: (np.nan
-                                                              if isinstance(x, float) and np.isnan(x)
-                                                              else vec[col].get(x, replace_unseen)))
+    column_categorizer = lambda col: df[col].apply(
+        lambda x: (np.nan if isinstance(x, float) and np.isnan(x) else vec[col].get(x, replace_unseen))
+    )
     categ_columns = {col: column_categorizer(col) for col in columns}
     return df.assign(**categ_columns)
 
 
-@column_duplicatable('value_maps')
+@column_duplicatable("value_maps")
 @curry
 @log_learner_time(learner_name="value_mapper")
-def value_mapper(df: pd.DataFrame,
-                 value_maps: Dict[str, Dict],
-                 ignore_unseen: bool = True,
-                 replace_unseen_to: Any = np.nan) -> pd.DataFrame:
+def value_mapper(
+    df: pd.DataFrame, value_maps: Dict[str, Dict], ignore_unseen: bool = True, replace_unseen_to: Any = np.nan
+) -> pd.DataFrame:
     """
     Map values in selected columns in the DataFrame according to dictionaries of replacements.
     Learner wrapper for apply_replacements
@@ -390,8 +393,7 @@ def value_mapper(df: pd.DataFrame,
         Default value to replace when original value is not present in the `vec` dict for the feature.
     """
 
-    def new_col_value_map(old_col_value_map: Dict[Any, Any],
-                          new_keys: List[Any]) -> Dict[Any, Dict]:
+    def new_col_value_map(old_col_value_map: Dict[Any, Any], new_keys: List[Any]) -> Dict[Any, Dict]:
         old_keys = old_col_value_map.keys()
         return {key: old_col_value_map[key] if key in old_keys else key for key in new_keys}
 
@@ -405,15 +407,17 @@ def value_mapper(df: pd.DataFrame,
     return p, p(df), {"value_maps": value_maps}
 
 
-@column_duplicatable('columns_to_truncate')
+@column_duplicatable("columns_to_truncate")
 @curry
 @log_learner_time(learner_name="truncate_categorical")
-def truncate_categorical(df: pd.DataFrame,
-                         columns_to_truncate: List[str],
-                         percentile: float,
-                         replacement: Union[str, float] = -9999,
-                         replace_unseen: Union[str, float] = -9999,
-                         store_mapping: bool = False) -> LearnerReturnType:
+def truncate_categorical(
+    df: pd.DataFrame,
+    columns_to_truncate: List[str],
+    percentile: float,
+    replacement: Union[str, float] = -9999,
+    replace_unseen: Union[str, float] = -9999,
+    store_mapping: bool = False,
+) -> LearnerReturnType:
     """
     Truncate infrequent categories and replace them by a single one.
     You can think of it like "others" category.
@@ -456,9 +460,8 @@ def truncate_categorical(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("truncate_categorical")
 
-    log: LearnerLogType = {'truncate_categorical': {
-        'transformed_column': columns_to_truncate,
-        'replace_unseen': replace_unseen}
+    log: LearnerLogType = {
+        "truncate_categorical": {"transformed_column": columns_to_truncate, "replace_unseen": replace_unseen}
     }
 
     if store_mapping:
@@ -470,13 +473,12 @@ def truncate_categorical(df: pd.DataFrame,
 truncate_categorical.__doc__ += learner_return_docstring("Truncate Categorical")
 
 
-@column_duplicatable('columns_to_rank')
+@column_duplicatable("columns_to_rank")
 @curry
 @log_learner_time(learner_name="rank_categorical")
-def rank_categorical(df: pd.DataFrame,
-                     columns_to_rank: List[str],
-                     replace_unseen: Union[str, float] = nan,
-                     store_mapping: bool = False) -> LearnerReturnType:
+def rank_categorical(
+    df: pd.DataFrame, columns_to_rank: List[str], replace_unseen: Union[str, float] = nan, store_mapping: bool = False
+) -> LearnerReturnType:
     """
     Rank categorical features by their frequency in the train set.
 
@@ -500,12 +502,15 @@ def rank_categorical(df: pd.DataFrame,
         Whether to store the feature value -> integer dictionary in the log
     """
 
-    col_categ_getter = lambda col: (df[col]
-                                    .value_counts()
-                                    .reset_index()
-                                    .sort_values([col, "index"], ascending=[False, True])
-                                    .set_index("index")[col]
-                                    .rank(method="first", ascending=False).to_dict())
+    col_categ_getter = lambda col: (
+        df[col]
+        .value_counts()
+        .reset_index()
+        .sort_values([col, "index"], ascending=[False, True])
+        .set_index("index")[col]
+        .rank(method="first", ascending=False)
+        .to_dict()
+    )
 
     vec = {column: col_categ_getter(column) for column in columns_to_rank}
 
@@ -514,13 +519,12 @@ def rank_categorical(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("rank_categorical")
 
-    log: LearnerLogType = {'rank_categorical': {
-        'transformed_column': columns_to_rank,
-        'replace_unseen': replace_unseen}
+    log: LearnerLogType = {
+        "rank_categorical": {"transformed_column": columns_to_rank, "replace_unseen": replace_unseen}
     }
 
     if store_mapping:
-        log['rank_categorical']['mapping'] = vec
+        log["rank_categorical"]["mapping"] = vec
 
     return p, p(df), log
 
@@ -528,13 +532,12 @@ def rank_categorical(df: pd.DataFrame,
 rank_categorical.__doc__ += learner_return_docstring("Rank Categorical")
 
 
-@column_duplicatable('columns_to_categorize')
+@column_duplicatable("columns_to_categorize")
 @curry
-@log_learner_time(learner_name='count_categorizer')
-def count_categorizer(df: pd.DataFrame,
-                      columns_to_categorize: List[str],
-                      replace_unseen: int = -1,
-                      store_mapping: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="count_categorizer")
+def count_categorizer(
+    df: pd.DataFrame, columns_to_categorize: List[str], replace_unseen: int = -1, store_mapping: bool = False
+) -> LearnerReturnType:
     """
     Replaces categorical variables by count.
 
@@ -567,13 +570,12 @@ def count_categorizer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("count_categorizer")
 
-    log: LearnerLogType = {'count_categorizer': {
-        'transformed_column': columns_to_categorize,
-        'replace_unseen': replace_unseen}
+    log: LearnerLogType = {
+        "count_categorizer": {"transformed_column": columns_to_categorize, "replace_unseen": replace_unseen}
     }
 
     if store_mapping:
-        log['count_categorizer']['mapping'] = vec
+        log["count_categorizer"]["mapping"] = vec
 
     return p, p(df), log
 
@@ -581,13 +583,15 @@ def count_categorizer(df: pd.DataFrame,
 count_categorizer.__doc__ += learner_return_docstring("Count Categorizer")
 
 
-@column_duplicatable('columns_to_categorize')
+@column_duplicatable("columns_to_categorize")
 @curry
-@log_learner_time(learner_name='label_categorizer')
-def label_categorizer(df: pd.DataFrame,
-                      columns_to_categorize: List[str],
-                      replace_unseen: Union[str, float] = nan,
-                      store_mapping: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="label_categorizer")
+def label_categorizer(
+    df: pd.DataFrame,
+    columns_to_categorize: List[str],
+    replace_unseen: Union[str, float] = nan,
+    store_mapping: bool = False,
+) -> LearnerReturnType:
     """
     Replaces categorical variables with a numeric identifier.
 
@@ -623,13 +627,12 @@ def label_categorizer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("label_categorizer")
 
-    log: LearnerLogType = {'label_categorizer': {
-        'transformed_column': columns_to_categorize,
-        'replace_unseen': replace_unseen}
+    log: LearnerLogType = {
+        "label_categorizer": {"transformed_column": columns_to_categorize, "replace_unseen": replace_unseen}
     }
 
     if store_mapping:
-        log['label_categorizer']['mapping'] = vec
+        log["label_categorizer"]["mapping"] = vec
 
     return p, p(df), log
 
@@ -637,13 +640,10 @@ def label_categorizer(df: pd.DataFrame,
 label_categorizer.__doc__ += learner_return_docstring("Label Categorizer")
 
 
-@column_duplicatable('columns_to_bin')
+@column_duplicatable("columns_to_bin")
 @curry
-@log_learner_time(learner_name='quantile_biner')
-def quantile_biner(df: pd.DataFrame,
-                   columns_to_bin: List[str],
-                   q: int = 4,
-                   right: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="quantile_biner")
+def quantile_biner(df: pd.DataFrame, columns_to_bin: List[str], q: int = 4, right: bool = False) -> LearnerReturnType:
     """
     Discretize continuous numerical columns into its quantiles. Uses pandas.qcut
     to find the bins and then numpy.digitize to fit the columns into bins.
@@ -684,9 +684,7 @@ def quantile_biner(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("quantile_biner")
 
-    log = {'quantile_biner': {
-        'transformed_column': columns_to_bin,
-        'q': q}}
+    log = {"quantile_biner": {"transformed_column": columns_to_bin, "q": q}}
 
     return p, p(df), log
 
@@ -694,14 +692,16 @@ def quantile_biner(df: pd.DataFrame,
 quantile_biner.__doc__ += learner_return_docstring("Quantile Biner")
 
 
-@column_duplicatable('columns_to_categorize')
+@column_duplicatable("columns_to_categorize")
 @curry
-@log_learner_time(learner_name='onehot_categorizer')
-def onehot_categorizer(df: pd.DataFrame,
-                       columns_to_categorize: List[str],
-                       hardcode_nans: bool = False,
-                       drop_first_column: bool = False,
-                       store_mapping: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="onehot_categorizer")
+def onehot_categorizer(
+    df: pd.DataFrame,
+    columns_to_categorize: List[str],
+    hardcode_nans: bool = False,
+    drop_first_column: bool = False,
+    store_mapping: bool = False,
+) -> LearnerReturnType:
     """
     Onehot encoding on categorical columns.
     Encoded columns are removed and substituted by columns named
@@ -732,31 +732,43 @@ def onehot_categorizer(df: pd.DataFrame,
         Whether to store the feature value -> integer dictionary in the log
     """
 
-    categ_getter = lambda col: list(np.sort(df[col].dropna(axis=0, how='any').unique()))
+    categ_getter = lambda col: list(np.sort(df[col].dropna(axis=0, how="any").unique()))
     vec = {column: categ_getter(column) for column in sorted(columns_to_categorize)}
 
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
-        make_dummies = lambda col: dict(map(lambda categ: ("fklearn_feat__" + col + "==" + str(categ),
-                                                           (new_df[col] == categ).astype(int)),
-                                            vec[col][int(drop_first_column):]))
+        make_dummies = lambda col: dict(
+            map(
+                lambda categ: ("fklearn_feat__" + col + "==" + str(categ), (new_df[col] == categ).astype(int)),
+                vec[col][int(drop_first_column) :],
+            )
+        )
 
-        oh_cols = dict(mapcat(lambda col: merge(make_dummies(col),
-                                                {"fklearn_feat__" + col + "==" + "nan":
-                                                    (~new_df[col].isin(vec[col])).astype(int)} if hardcode_nans
-                                                else {}).items(),
-                              columns_to_categorize))
+        oh_cols = dict(
+            mapcat(
+                lambda col: merge(
+                    make_dummies(col),
+                    {"fklearn_feat__" + col + "==" + "nan": (~new_df[col].isin(vec[col])).astype(int)}
+                    if hardcode_nans
+                    else {},
+                ).items(),
+                columns_to_categorize,
+            )
+        )
 
         return new_df.assign(**oh_cols).drop(columns_to_categorize, axis=1)
 
     p.__doc__ = learner_pred_fn_docstring("onehot_categorizer")
 
-    log = {'onehot_categorizer': {
-        'transformed_column': columns_to_categorize,
-        'hardcode_nans': hardcode_nans,
-        'drop_first_column': drop_first_column}}
+    log = {
+        "onehot_categorizer": {
+            "transformed_column": columns_to_categorize,
+            "hardcode_nans": hardcode_nans,
+            "drop_first_column": drop_first_column,
+        }
+    }
 
     if store_mapping:
-        log['onehot_categorizer']['mapping'] = vec
+        log["onehot_categorizer"]["mapping"] = vec
 
     return p, p(df), log
 
@@ -764,15 +776,17 @@ def onehot_categorizer(df: pd.DataFrame,
 onehot_categorizer.__doc__ += learner_return_docstring("Onehot Categorizer")
 
 
-@column_duplicatable('columns_to_categorize')
+@column_duplicatable("columns_to_categorize")
 @curry
-@log_learner_time(learner_name='target_categorizer')
-def target_categorizer(df: pd.DataFrame,
-                       columns_to_categorize: List[str],
-                       target_column: str,
-                       smoothing: float = 1.0,
-                       ignore_unseen: bool = True,
-                       store_mapping: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="target_categorizer")
+def target_categorizer(
+    df: pd.DataFrame,
+    columns_to_categorize: List[str],
+    target_column: str,
+    smoothing: float = 1.0,
+    ignore_unseen: bool = True,
+    store_mapping: bool = False,
+) -> LearnerReturnType:
     """
     Replaces categorical variables with the smoothed mean of the target variable by category.
     Uses a weighted average with the overall mean of the target variable for smoothing.
@@ -809,12 +823,13 @@ def target_categorizer(df: pd.DataFrame,
     replace_unseen = nan if ignore_unseen else target_mean
 
     def categ_target_dict(column: str) -> Dict:
-        column_agg = df.groupby(column)[target_column].agg(['count', 'mean'])
-        column_target_mean = column_agg['mean']
-        column_target_count = column_agg['count']
+        column_agg = df.groupby(column)[target_column].agg(["count", "mean"])
+        column_target_mean = column_agg["mean"]
+        column_target_count = column_agg["count"]
 
-        smoothed_target_mean = (column_target_count * column_target_mean + smoothing * target_mean) / \
-                               (column_target_count + smoothing)
+        smoothed_target_mean = (column_target_count * column_target_mean + smoothing * target_mean) / (
+            column_target_count + smoothing
+        )
 
         return smoothed_target_mean.to_dict()
 
@@ -825,15 +840,17 @@ def target_categorizer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("target_categorizer")
 
-    log = {'target_categorizer': {
-        'transformed_columns': columns_to_categorize,
-        'target_column': target_column,
-        'smoothing': smoothing,
-        'ignore_unseen': ignore_unseen}
+    log = {
+        "target_categorizer": {
+            "transformed_columns": columns_to_categorize,
+            "target_column": target_column,
+            "smoothing": smoothing,
+            "ignore_unseen": ignore_unseen,
+        }
     }
 
     if store_mapping:
-        log['target_categorizer']['mapping'] = vec
+        log["target_categorizer"]["mapping"] = vec
 
     return p, p(df), log
 
@@ -841,11 +858,10 @@ def target_categorizer(df: pd.DataFrame,
 target_categorizer.__doc__ += learner_return_docstring("Target Categorizer")
 
 
-@column_duplicatable('columns_to_scale')
+@column_duplicatable("columns_to_scale")
 @curry
-@log_learner_time(learner_name='standard_scaler')
-def standard_scaler(df: pd.DataFrame,
-                    columns_to_scale: List[str]) -> LearnerReturnType:
+@log_learner_time(learner_name="standard_scaler")
+def standard_scaler(df: pd.DataFrame, columns_to_scale: List[str]) -> LearnerReturnType:
     """
     Fits a standard scaler to the dataset.
 
@@ -871,14 +887,12 @@ def standard_scaler(df: pd.DataFrame,
 
     def p(new_data_set: pd.DataFrame) -> pd.DataFrame:
         new_data = scaler.transform(new_data_set[columns_to_scale].values)
-        new_cols = pd.DataFrame(data=new_data, columns=columns_to_scale).to_dict('list')
+        new_cols = pd.DataFrame(data=new_data, columns=columns_to_scale).to_dict("list")
         return new_data_set.assign(**new_cols)
 
     p.__doc__ = learner_pred_fn_docstring("standard_scaler")
 
-    log = {'standard_scaler': {
-        'standard_scaler': scaler.get_params(),
-        'transformed_column': columns_to_scale}}
+    log = {"standard_scaler": {"standard_scaler": scaler.get_params(), "transformed_column": columns_to_scale}}
 
     return p, p(df), log
 
@@ -886,13 +900,15 @@ def standard_scaler(df: pd.DataFrame,
 standard_scaler.__doc__ += learner_return_docstring("Standard Scaler")
 
 
-@column_duplicatable('columns_to_transform')
+@column_duplicatable("columns_to_transform")
 @curry
-@log_learner_time(learner_name='custom_transformer')
-def custom_transformer(df: pd.DataFrame,
-                       columns_to_transform: List[str],
-                       transformation_function: Callable[[pd.DataFrame], pd.DataFrame],
-                       is_vectorized: bool = False) -> LearnerReturnType:
+@log_learner_time(learner_name="custom_transformer")
+def custom_transformer(
+    df: pd.DataFrame,
+    columns_to_transform: List[str],
+    transformation_function: Callable[[pd.DataFrame], pd.DataFrame],
+    is_vectorized: bool = False,
+) -> LearnerReturnType:
     """
     Applies a custom function to the desired columns.
 
@@ -924,9 +940,11 @@ def custom_transformer(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("custom_transformer")
 
-    log = {'custom_transformer': {
-        'transformed_column': columns_to_transform,
-        'transformation_function': transformation_function.__name__}
+    log = {
+        "custom_transformer": {
+            "transformed_column": columns_to_transform,
+            "transformation_function": transformation_function.__name__,
+        }
     }
 
     return p, p(df), log
@@ -936,12 +954,14 @@ custom_transformer.__doc__ += learner_return_docstring("Custom Transformer")
 
 
 @curry
-@log_learner_time(learner_name='null_injector')
-def null_injector(df: pd.DataFrame,
-                  proportion: float,
-                  columns_to_inject: Optional[List[str]] = None,
-                  groups: Optional[List[List[str]]] = None,
-                  seed: int = 1) -> LearnerReturnType:
+@log_learner_time(learner_name="null_injector")
+def null_injector(
+    df: pd.DataFrame,
+    proportion: float,
+    columns_to_inject: Optional[List[str]] = None,
+    groups: Optional[List[List[str]]] = None,
+    seed: int = 1,
+) -> LearnerReturnType:
     """
     Injects null into columns
 
@@ -963,9 +983,9 @@ def null_injector(df: pd.DataFrame,
         Random seed for consistency.
     """
     if proportion < 0 or proportion > 1:
-        raise ValueError('proportions must be between 0 and 1.')
+        raise ValueError("proportions must be between 0 and 1.")
     if not ((columns_to_inject is None) ^ (groups is None)):
-        raise ValueError('Either columns_to_inject or groups must be None.')
+        raise ValueError("Either columns_to_inject or groups must be None.")
 
     n_rows = df.shape[0]
 
@@ -984,11 +1004,7 @@ def null_injector(df: pd.DataFrame,
 
     p.__doc__ = learner_pred_fn_docstring("null_injector")
 
-    log = {'null_injector': {
-        "columns_to_inject": columns_to_inject,
-        "proportion": proportion,
-        "groups": groups
-    }}
+    log = {"null_injector": {"columns_to_inject": columns_to_inject, "proportion": proportion, "groups": groups}}
 
     return p, null_data, log
 
@@ -997,11 +1013,14 @@ null_injector.__doc__ += learner_return_docstring("Null Injector")
 
 
 @curry
-@log_learner_time(learner_name='missing_warner')
-def missing_warner(df: pd.DataFrame, cols_list: List[str],
-                   new_column_name: str = "has_unexpected_missing",
-                   detailed_warning: bool = False,
-                   detailed_column_name: Optional[str] = None) -> LearnerReturnType:
+@log_learner_time(learner_name="missing_warner")
+def missing_warner(
+    df: pd.DataFrame,
+    cols_list: List[str],
+    new_column_name: str = "has_unexpected_missing",
+    detailed_warning: bool = False,
+    detailed_column_name: Optional[str] = None,
+) -> LearnerReturnType:
     """
     Creates a new column to warn about rows that columns that don't have missing in the training set
     but have missing on the scoring
@@ -1019,9 +1038,10 @@ def missing_warner(df: pd.DataFrame, cols_list: List[str],
         Name of the column created to alert the existence of missing values
     """
 
-    if (detailed_warning is False and detailed_column_name is not None) or \
-            (detailed_warning is True and detailed_column_name is None):
-        raise ValueError('Either detailed_warning and detailed_column_name should be defined or both should be False.')
+    if (detailed_warning is False and detailed_column_name is not None) or (
+        detailed_warning is True and detailed_column_name is None
+    ):
+        raise ValueError("Either detailed_warning and detailed_column_name should be defined or both should be False.")
 
     df_selected = df[cols_list]
     cols_without_missing = df_selected.loc[:, df_selected.isna().sum(axis=0) == 0].columns.tolist()
@@ -1044,10 +1064,7 @@ def missing_warner(df: pd.DataFrame, cols_list: List[str],
 
     p.__doc__ = learner_pred_fn_docstring("missing_warner")
 
-    log = {"missing_warner": {
-        "cols_list": cols_list,
-        "cols_without_missing": cols_without_missing}
-    }
+    log = {"missing_warner": {"cols_list": cols_list, "cols_without_missing": cols_without_missing}}
 
     return p, df, log
 

--- a/src/fklearn/training/unsupervised.py
+++ b/src/fklearn/training/unsupervised.py
@@ -11,12 +11,14 @@ from fklearn.training.utils import log_learner_time, expand_features_encoded
 
 
 @curry
-@log_learner_time(learner_name='isolation_forest_learner')
-def isolation_forest_learner(df: pd.DataFrame,
-                             features: List[str],
-                             params: Dict[str, Any] = None,
-                             prediction_column: str = "prediction",
-                             encode_extra_cols: bool = True) -> LearnerReturnType:
+@log_learner_time(learner_name="isolation_forest_learner")
+def isolation_forest_learner(
+    df: pd.DataFrame,
+    features: List[str],
+    params: Dict[str, Any] = None,
+    prediction_column: str = "prediction",
+    encode_extra_cols: bool = True,
+) -> LearnerReturnType:
     """
     Fits an anomaly detection algorithm (Isolation Forest) to the dataset
 
@@ -52,20 +54,22 @@ def isolation_forest_learner(df: pd.DataFrame,
     model.fit(df[features].values)
 
     def p(new_df: pd.DataFrame) -> pd.DataFrame:
-        output_col = {prediction_column: model.decision_function(
-            new_df[features])}
+        output_col = {prediction_column: model.decision_function(new_df[features])}
 
         return new_df.assign(**output_col)
 
     p.__doc__ = learner_pred_fn_docstring("isolation_forest_learner")
 
-    log = {'isolation_forest_learner': {
-        'features': features,
-        'parameters': params,
-        'prediction_column': prediction_column,
-        'package': "sklearn",
-        'package_version': sklearn.__version__,
-        'training_samples': len(df)}}
+    log = {
+        "isolation_forest_learner": {
+            "features": features,
+            "parameters": params,
+            "prediction_column": prediction_column,
+            "package": "sklearn",
+            "package_version": sklearn.__version__,
+            "training_samples": len(df),
+        }
+    }
 
     return p, p(df), log
 

--- a/src/fklearn/training/utils.py
+++ b/src/fklearn/training/utils.py
@@ -16,7 +16,7 @@ def log_learner_time(learner: UncurriedLearnerFnType, learner_name: str) -> Uncu
     def timed_learner(*args: Any, **kwargs: Any) -> LearnerReturnType:
         t0 = time()
         (p, d, l) = learner(*args, **kwargs)
-        return p, d, fp.assoc_in(l, [learner_name, 'running_time'], "%2.3f s" % (time() - t0))
+        return p, d, fp.assoc_in(l, [learner_name, "running_time"], "%2.3f s" % (time() - t0))
 
     return timed_learner
 
@@ -25,14 +25,13 @@ def log_learner_time(learner: UncurriedLearnerFnType, learner_name: str) -> Uncu
 def print_learner_run(learner: UncurriedLearnerFnType, learner_name: str) -> UncurriedLearnerFnType:
     @wraps(learner)
     def printed_learner(*args: Any, **kwargs: Any) -> LearnerReturnType:
-        print('%s running' % learner_name)
+        print("%s running" % learner_name)
         return learner(*args, **kwargs)
 
     return printed_learner
 
 
-def expand_features_encoded(df: pd.DataFrame,
-                            features: List[str]) -> List[str]:
+def expand_features_encoded(df: pd.DataFrame, features: List[str]) -> List[str]:
 
     """
     Expand the list of features to include features created automatically
@@ -70,10 +69,9 @@ def expand_features_encoded(df: pd.DataFrame,
 
     def remove_original_pre_encoded_features(features: List[str], encoded_features: List[str]) -> List[str]:
         expr = r"fklearn_feat__(.*)=="
-        original_preencoded_features: List[str] = reduce(lambda x, y: x + y,
-                                                         (map(lambda x: re.findall(expr, x),
-                                                              encoded_features)),
-                                                         [])
+        original_preencoded_features: List[str] = reduce(
+            lambda x, y: x + y, (map(lambda x: re.findall(expr, x), encoded_features)), []
+        )
         return list(filter(lambda col: col not in set(original_preencoded_features), features))
 
     all_fklearn_features = fklearn_features(df)

--- a/src/fklearn/tuning/model_agnostic_fc.py
+++ b/src/fklearn/tuning/model_agnostic_fc.py
@@ -8,9 +8,7 @@ from fklearn.types import LogType
 
 
 @curry
-def correlation_feature_selection(train_set: pd.DataFrame,
-                                  features: List[str],
-                                  threshold: float = 1.0) -> LogType:
+def correlation_feature_selection(train_set: pd.DataFrame, features: List[str], threshold: float = 1.0) -> LogType:
     """
     Feature selection based on correlation
 
@@ -32,20 +30,23 @@ def correlation_feature_selection(train_set: pd.DataFrame,
     """
 
     correlogram = train_set[features].corr()
-    correlogram_diag = pd.DataFrame(tril(correlogram.values),
-                                    columns=correlogram.columns,
-                                    index=correlogram.index)
+    correlogram_diag = pd.DataFrame(tril(correlogram.values), columns=correlogram.columns, index=correlogram.index)
 
-    features_to_drop = pd.melt(correlogram_diag.reset_index(), id_vars='index') \
-        .query('index!=variable') \
-        .query('abs(value)>0.0') \
-        .query('abs(value)>=%f' % threshold)["variable"].tolist()
+    features_to_drop = (
+        pd.melt(correlogram_diag.reset_index(), id_vars="index")
+        .query("index!=variable")
+        .query("abs(value)>0.0")
+        .query("abs(value)>=%f" % threshold)["variable"]
+        .tolist()
+    )
 
     final_features = list(set(features) - set(features_to_drop))
 
-    return {"feature_corr": correlogram.to_dict(),
-            "features_to_drop": features_to_drop,
-            "final_features": final_features}
+    return {
+        "feature_corr": correlogram.to_dict(),
+        "features_to_drop": features_to_drop,
+        "final_features": final_features,
+    }
 
 
 @curry
@@ -76,6 +77,8 @@ def variance_feature_selection(train_set: pd.DataFrame, features: List[str], thr
 
     final_features = list(set(features) - set(features_to_drop))
 
-    return {"feature_var": feature_var.to_dict(),
-            "features_to_drop": features_to_drop,
-            "final_features": final_features}
+    return {
+        "feature_var": feature_var.to_dict(),
+        "features_to_drop": features_to_drop,
+        "final_features": final_features,
+    }

--- a/src/fklearn/tuning/parameter_tuners.py
+++ b/src/fklearn/tuning/parameter_tuners.py
@@ -13,15 +13,17 @@ SaveIntermediaryFnType = Callable[[ValidatorReturnType], None]
 
 
 @curry
-def random_search_tuner(space: LogType,
-                        train_set: pd.DataFrame,
-                        param_train_fn: Callable[[LogType], LearnerFnType],
-                        split_fn: SplitterFnType,
-                        eval_fn: EvalFnType,
-                        iterations: int,
-                        random_seed: int = 1,
-                        save_intermediary_fn: SaveIntermediaryFnType = None,
-                        n_jobs: int = 1) -> List[ValidatorReturnType]:
+def random_search_tuner(
+    space: LogType,
+    train_set: pd.DataFrame,
+    param_train_fn: Callable[[LogType], LearnerFnType],
+    split_fn: SplitterFnType,
+    eval_fn: EvalFnType,
+    iterations: int,
+    random_seed: int = 1,
+    save_intermediary_fn: SaveIntermediaryFnType = None,
+    n_jobs: int = 1,
+) -> List[ValidatorReturnType]:
     """
     Runs several training functions with each run taken from the parameter space
 
@@ -104,15 +106,17 @@ def random_search_tuner(space: LogType,
 
 
 @curry
-def grid_search_cv(space: LogType,
-                   train_set: pd.DataFrame,
-                   param_train_fn: Callable[[LogType], LearnerFnType],
-                   split_fn: SplitterFnType,
-                   eval_fn: EvalFnType,
-                   save_intermediary_fn: SaveIntermediaryFnType = None,
-                   load_intermediary_fn: Callable[[str], List[ValidatorReturnType]] = None,
-                   warm_start_file: str = None,
-                   n_jobs: int = 1) -> List[ValidatorReturnType]:
+def grid_search_cv(
+    space: LogType,
+    train_set: pd.DataFrame,
+    param_train_fn: Callable[[LogType], LearnerFnType],
+    split_fn: SplitterFnType,
+    eval_fn: EvalFnType,
+    save_intermediary_fn: SaveIntermediaryFnType = None,
+    load_intermediary_fn: Callable[[str], List[ValidatorReturnType]] = None,
+    warm_start_file: str = None,
+    n_jobs: int = 1,
+) -> List[ValidatorReturnType]:
     """
     Runs several training functions with each run taken from the parameter space
 
@@ -188,7 +192,7 @@ def grid_search_cv(space: LogType,
     def tune_iteration(iter_space: LogType) -> ValidatorReturnType:
         train_fn = param_train_fn(iter_space)
         validator_log = validation_fn(train_data=train_set, split_fn=split_fn, train_fn=train_fn, eval_fn=eval_fn)
-        validator_log['iter_space'] = OrderedDict(sorted(iter_space.items()))
+        validator_log["iter_space"] = OrderedDict(sorted(iter_space.items()))
 
         if save_intermediary_fn is not None:
             save_intermediary_fn(validator_log)
@@ -201,7 +205,7 @@ def grid_search_cv(space: LogType,
 
     if warm_start_file is not None and load_intermediary_fn is not None:
         results = load_intermediary_fn(warm_start_file)
-        computed_combs = set([tuple(log['iter_space'].values()) for log in results])  # type: ignore
+        computed_combs = set([tuple(log["iter_space"].values()) for log in results])  # type: ignore
         combinations = combinations.difference(computed_combs)
 
     return [tune_iteration({k_v[0]: k_v[1] for k_v in zip(sorted_space_keys, comb)}) for comb in combinations]

--- a/src/fklearn/tuning/samplers.py
+++ b/src/fklearn/tuning/samplers.py
@@ -7,135 +7,141 @@ from joblib import Parallel, delayed
 from numpy import random
 from toolz.curried import curry, first, compose, valfilter, sorted, pipe, take
 
-from fklearn.tuning.utils import order_feature_importance_avg_from_logs, get_best_performing_log, gen_dict_extract, \
-    get_avg_metric_from_extractor, get_used_features, gen_validator_log
+from fklearn.tuning.utils import (
+    order_feature_importance_avg_from_logs,
+    get_best_performing_log,
+    gen_dict_extract,
+    get_avg_metric_from_extractor,
+    get_used_features,
+    gen_validator_log,
+)
 from fklearn.types import EvalFnType, ExtractorFnType, LogListType, LogType, PredictFnType
 
 
 @curry
-def remove_by_feature_importance(log: LogType,
-                                 num_removed_by_step: int = 5) -> List[str]:
+def remove_by_feature_importance(log: LogType, num_removed_by_step: int = 5) -> List[str]:
     """
-        Performs feature selection based on feature importance
+    Performs feature selection based on feature importance
 
-        Parameters
-        ----------
-        log : dict
-            Dictionaries evaluations.
+    Parameters
+    ----------
+    log : dict
+        Dictionaries evaluations.
 
-        num_removed_by_step: int (default 5)
-            The number of features to remove
+    num_removed_by_step: int (default 5)
+        The number of features to remove
 
-        Returns
-        ----------
-        features: list of str
-            The remaining features after removing based on feature importance
+    Returns
+    ----------
+    features: list of str
+        The remaining features after removing based on feature importance
 
     """
     return order_feature_importance_avg_from_logs(log)[:-num_removed_by_step]
 
 
 @curry
-def remove_features_subsets(log_list: LogListType,
-                            extractor: ExtractorFnType,
-                            metric_name: str,
-                            num_removed_by_step: int = 1) -> List[Tuple[str, ...]]:
+def remove_features_subsets(
+    log_list: LogListType, extractor: ExtractorFnType, metric_name: str, num_removed_by_step: int = 1
+) -> List[Tuple[str, ...]]:
     """
-        Performs feature selection based on the best performing model out of
-        several trained models
+    Performs feature selection based on the best performing model out of
+    several trained models
 
-        Parameters
-        ----------
-        log_list : list of dict
-            A list of log-like lists of dictionaries evaluations.
+    Parameters
+    ----------
+    log_list : list of dict
+        A list of log-like lists of dictionaries evaluations.
 
-        extractor: function string -> float
-            A extractor that take a string and returns the value of that string on a dict
+    extractor: function string -> float
+        A extractor that take a string and returns the value of that string on a dict
 
-        metric_name: str
-            String with the name of the column that refers to the metric column to be extracted
+    metric_name: str
+        String with the name of the column that refers to the metric column to be extracted
 
-        num_removed_by_step: int (default 1)
-            The number of features to remove
+    num_removed_by_step: int (default 1)
+        The number of features to remove
 
-        Returns
-        ----------
-        keys: list of str
-            The remaining keys of feature sets after choosing the current best subset
+    Returns
+    ----------
+    keys: list of str
+        The remaining keys of feature sets after choosing the current best subset
 
     """
 
     best_log = get_best_performing_log(log_list, extractor, metric_name)
-    best_subset: List[str] = first(gen_dict_extract('used_subsets', best_log))
+    best_subset: List[str] = first(gen_dict_extract("used_subsets", best_log))
 
     return list(combinations(best_subset, len(best_subset) - num_removed_by_step))
 
 
 @curry
-def remove_by_feature_shuffling(log: LogType,
-                                predict_fn: PredictFnType,
-                                eval_fn: EvalFnType,
-                                eval_data: pd.DataFrame,
-                                extractor: ExtractorFnType,
-                                metric_name: str,
-                                max_removed_by_step: int = 50,
-                                threshold: float = 0.005,
-                                speed_up_by_importance: bool = False,
-                                parallel: bool = False,
-                                nthread: int = 1,
-                                seed: int = 7) -> List[str]:
+def remove_by_feature_shuffling(
+    log: LogType,
+    predict_fn: PredictFnType,
+    eval_fn: EvalFnType,
+    eval_data: pd.DataFrame,
+    extractor: ExtractorFnType,
+    metric_name: str,
+    max_removed_by_step: int = 50,
+    threshold: float = 0.005,
+    speed_up_by_importance: bool = False,
+    parallel: bool = False,
+    nthread: int = 1,
+    seed: int = 7,
+) -> List[str]:
 
     """
-        Performs feature selection based on the evaluation of the test vs the
-        evaluation of the test with randomly shuffled features
+    Performs feature selection based on the evaluation of the test vs the
+    evaluation of the test with randomly shuffled features
 
-        Parameters
-        ----------
-        log : LogType
-            Dictionaries evaluations.
+    Parameters
+    ----------
+    log : LogType
+        Dictionaries evaluations.
 
-        predict_fn: function pandas.DataFrame -> pandas.DataFrame
-            A partially defined predictor that takes a DataFrame and returns the
-            predicted score for this dataframe
+    predict_fn: function pandas.DataFrame -> pandas.DataFrame
+        A partially defined predictor that takes a DataFrame and returns the
+        predicted score for this dataframe
 
-        eval_fn : function DataFrame -> log dict
-            A partially defined evaluation function that takes a dataset with prediction and
-            returns the evaluation logs.
+    eval_fn : function DataFrame -> log dict
+        A partially defined evaluation function that takes a dataset with prediction and
+        returns the evaluation logs.
 
-        eval_data: pandas.DataFrame
-            Data used to evaluate the model after shuffling
+    eval_data: pandas.DataFrame
+        Data used to evaluate the model after shuffling
 
-        extractor: function str -> float
-            A extractor that take a string and returns the value of that string on a dict
+    extractor: function str -> float
+        A extractor that take a string and returns the value of that string on a dict
 
-        metric_name: str
-            String with the name of the column that refers to the metric column to be extracted
+    metric_name: str
+        String with the name of the column that refers to the metric column to be extracted
 
-        max_removed_by_step: int (default 5)
-            The maximum number of features to remove. It will only consider the least max_removed_by_step in terms of
-            feature importance. If speed_up_by_importance=True it will first filter the least relevant feature an
-            shuffle only those. If speed_up_by_importance=False it will shuffle all features and drop the last
-            max_removed_by_step in terms of PIMP. In both cases, the features will only be removed if drop in
-            performance is up to the defined threshold.
+    max_removed_by_step: int (default 5)
+        The maximum number of features to remove. It will only consider the least max_removed_by_step in terms of
+        feature importance. If speed_up_by_importance=True it will first filter the least relevant feature an
+        shuffle only those. If speed_up_by_importance=False it will shuffle all features and drop the last
+        max_removed_by_step in terms of PIMP. In both cases, the features will only be removed if drop in
+        performance is up to the defined threshold.
 
-        threshold: float (default 0.005)
-            Threshold for model performance comparison
+    threshold: float (default 0.005)
+        Threshold for model performance comparison
 
-        speed_up_by_importance: bool (default True)
-            If it should narrow search looking at feature importance first before getting PIMP importance. If True,
-            will only shuffle the top num_removed_by_step in terms of feature importance.
+    speed_up_by_importance: bool (default True)
+        If it should narrow search looking at feature importance first before getting PIMP importance. If True,
+        will only shuffle the top num_removed_by_step in terms of feature importance.
 
-        parallel: bool (default False)
+    parallel: bool (default False)
 
-        nthread: int (default 1)
+    nthread: int (default 1)
 
-        seed: int (default 7)
-            Random seed
+    seed: int (default 7)
+        Random seed
 
-        Returns
-        ----------
-        features: list of str
-            The remaining features after removing based on feature importance
+    Returns
+    ----------
+    features: list of str
+        The remaining features after removing based on feature importance
 
     """
     random.seed(seed)
@@ -143,27 +149,38 @@ def remove_by_feature_shuffling(log: LogType,
     curr_metric = get_avg_metric_from_extractor(log, extractor, metric_name)
     eval_size = eval_data.shape[0]
 
-    features_to_shuffle = order_feature_importance_avg_from_logs(log)[-max_removed_by_step:] \
-        if speed_up_by_importance else get_used_features(log)
+    features_to_shuffle = (
+        order_feature_importance_avg_from_logs(log)[-max_removed_by_step:]
+        if speed_up_by_importance
+        else get_used_features(log)
+    )
 
     def shuffle(feature: str) -> pd.DataFrame:
         return eval_data.assign(**{feature: eval_data[feature].sample(frac=1.0)})
 
-    feature_to_delta_metric = compose(lambda m: curr_metric - m,
-                                      get_avg_metric_from_extractor(extractor=extractor, metric_name=metric_name),
-                                      gen_validator_log(fold_num=0, test_size=eval_size), eval_fn, predict_fn, shuffle)
+    feature_to_delta_metric = compose(
+        lambda m: curr_metric - m,
+        get_avg_metric_from_extractor(extractor=extractor, metric_name=metric_name),
+        gen_validator_log(fold_num=0, test_size=eval_size),
+        eval_fn,
+        predict_fn,
+        shuffle,
+    )
 
     if parallel:
         metrics = Parallel(n_jobs=nthread, backend="threading")(
-            delayed(feature_to_delta_metric)(feature) for feature in features_to_shuffle)
+            delayed(feature_to_delta_metric)(feature) for feature in features_to_shuffle
+        )
         feature_to_delta_metric = dict(zip(features_to_shuffle, metrics))
         gc.collect()
 
     else:
         feature_to_delta_metric = {feature: feature_to_delta_metric(feature) for feature in features_to_shuffle}
 
-    return pipe(feature_to_delta_metric,
-                valfilter(lambda delta_metric: delta_metric < threshold),
-                sorted(key=lambda f: feature_to_delta_metric.get(f)),
-                take(max_removed_by_step),
-                list)
+    return pipe(
+        feature_to_delta_metric,
+        valfilter(lambda delta_metric: delta_metric < threshold),
+        sorted(key=lambda f: feature_to_delta_metric.get(f)),
+        take(max_removed_by_step),
+        list,
+    )

--- a/src/fklearn/tuning/selectors.py
+++ b/src/fklearn/tuning/selectors.py
@@ -4,103 +4,121 @@ from toolz.curried import pipe, first, mapcat
 import pandas as pd
 
 from fklearn.tuning.samplers import remove_features_subsets, remove_by_feature_importance, remove_by_feature_shuffling
-from fklearn.tuning.stoppers import stop_by_num_features, stop_by_num_features_parallel, stop_by_iter_num, \
-    stop_by_no_improvement, stop_by_no_improvement_parallel, aggregate_stop_funcs
+from fklearn.tuning.stoppers import (
+    stop_by_num_features,
+    stop_by_num_features_parallel,
+    stop_by_iter_num,
+    stop_by_no_improvement,
+    stop_by_no_improvement_parallel,
+    aggregate_stop_funcs,
+)
 from fklearn.validation.validator import parallel_validator
-from fklearn.types import EvalFnType, ExtractorFnType, LearnerReturnType, ListLogListType, LogListType, SplitterFnType,\
-    ValidatorReturnType, LogType
+from fklearn.types import (
+    EvalFnType,
+    ExtractorFnType,
+    LearnerReturnType,
+    ListLogListType,
+    LogListType,
+    SplitterFnType,
+    ValidatorReturnType,
+    LogType,
+)
 
 SaveIntermediaryFnType = Callable[[List[ValidatorReturnType]], None]
 TuningLearnerFnType = Callable[[pd.DataFrame, List[str]], LearnerReturnType]
 
 
-def feature_importance_backward_selection(train_data: pd.DataFrame,
-                                          param_train_fn: TuningLearnerFnType,
-                                          features: List[str],
-                                          split_fn: SplitterFnType,
-                                          eval_fn: EvalFnType,
-                                          extractor: ExtractorFnType,
-                                          metric_name: str,
-                                          num_removed_by_step: int = 5,
-                                          threshold: float = 0.005,
-                                          early_stop: int = 2,
-                                          iter_limit: int = 50,
-                                          min_remaining_features: int = 50,
-                                          save_intermediary_fn: SaveIntermediaryFnType = None,
-                                          n_jobs: int = 1) -> ListLogListType:
+def feature_importance_backward_selection(
+    train_data: pd.DataFrame,
+    param_train_fn: TuningLearnerFnType,
+    features: List[str],
+    split_fn: SplitterFnType,
+    eval_fn: EvalFnType,
+    extractor: ExtractorFnType,
+    metric_name: str,
+    num_removed_by_step: int = 5,
+    threshold: float = 0.005,
+    early_stop: int = 2,
+    iter_limit: int = 50,
+    min_remaining_features: int = 50,
+    save_intermediary_fn: SaveIntermediaryFnType = None,
+    n_jobs: int = 1,
+) -> ListLogListType:
     """
-        Performs train-evaluation iterations while subsampling the used features
-        to compute statistics about feature relevance
+    Performs train-evaluation iterations while subsampling the used features
+    to compute statistics about feature relevance
 
-        Parameters
-        ----------
-        train_data : pandas.DataFrame
-            A Pandas' DataFrame with training data
+    Parameters
+    ----------
+    train_data : pandas.DataFrame
+        A Pandas' DataFrame with training data
 
-        param_train_fn : function (DataFrame, List of Strings) -> prediction_function, predictions_dataset, logs
-            A partially defined learning function that takes a training set and a feature list and
-            returns a predict function, a dataset with training predictions and training
-            logs.
+    param_train_fn : function (DataFrame, List of Strings) -> prediction_function, predictions_dataset, logs
+        A partially defined learning function that takes a training set and a feature list and
+        returns a predict function, a dataset with training predictions and training
+        logs.
 
-        features: list of str
-            Elements must be columns of the train_data
+    features: list of str
+        Elements must be columns of the train_data
 
-        split_fn : function pandas.DataFrame ->  list of tuple
-            Partially defined split function that takes a dataset and returns
-            a list of folds. Each fold is a Tuple of arrays. The fist array in
-            each tuple contains training indexes while the second array
-            contains validation indexes.
+    split_fn : function pandas.DataFrame ->  list of tuple
+        Partially defined split function that takes a dataset and returns
+        a list of folds. Each fold is a Tuple of arrays. The fist array in
+        each tuple contains training indexes while the second array
+        contains validation indexes.
 
-        eval_fn : function pandas.DataFrame -> dict
-            A partially defined evaluation function that takes a dataset with prediction and
-            returns the evaluation logs.
+    eval_fn : function pandas.DataFrame -> dict
+        A partially defined evaluation function that takes a dataset with prediction and
+        returns the evaluation logs.
 
-        extractor: function str -> float
-            A extractor that take a string and returns the value of that string on a dict
+    extractor: function str -> float
+        A extractor that take a string and returns the value of that string on a dict
 
-        metric_name: str
-            String with the name of the column that refers to the metric column to be extracted
+    metric_name: str
+        String with the name of the column that refers to the metric column to be extracted
 
-        num_removed_by_step: int (default 5)
-            Number of features removed at each iteration
+    num_removed_by_step: int (default 5)
+        Number of features removed at each iteration
 
-        threshold: float (default 0.005)
-            Threshold for model performance comparison
+    threshold: float (default 0.005)
+        Threshold for model performance comparison
 
-        early_stop: int (default 2)
-            Number of rounds without improvement before stopping process
+    early_stop: int (default 2)
+        Number of rounds without improvement before stopping process
 
-        iter_limit: int (default 50)
-            Maximum number of iterations before stopping
+    iter_limit: int (default 50)
+        Maximum number of iterations before stopping
 
-        min_remaining_features: int (default 50)
-            Minimum number of features that should remain in the model,
-            combining num_removed_by_step and iter_limit accomplishes the same
-            functionality as this parameter.
+    min_remaining_features: int (default 50)
+        Minimum number of features that should remain in the model,
+        combining num_removed_by_step and iter_limit accomplishes the same
+        functionality as this parameter.
 
-        save_intermediary_fn : function(log) -> save to file
-            Partially defined saver function that receives a log result from a
-            tuning step and appends it into a file
-            Example: save_intermediary_result(save_path='tuning.pkl')
+    save_intermediary_fn : function(log) -> save to file
+        Partially defined saver function that receives a log result from a
+        tuning step and appends it into a file
+        Example: save_intermediary_result(save_path='tuning.pkl')
 
-        n_jobs : int (default 1)
-            Number of parallel processes to spawn.
+    n_jobs : int (default 1)
+        Number of parallel processes to spawn.
 
-        Returns
-        ----------
-        Logs: list of list of dict
-            A list log-like lists of dictionaries evaluations. Each element of the
-            list is validation step of the algorithm.
+    Returns
+    ----------
+    Logs: list of list of dict
+        A list log-like lists of dictionaries evaluations. Each element of the
+        list is validation step of the algorithm.
 
     """
 
     selector_fn = remove_by_feature_importance(num_removed_by_step=num_removed_by_step)
 
     stop_fn = aggregate_stop_funcs(
-        stop_by_no_improvement(extractor=extractor, metric_name=metric_name, early_stop=early_stop,
-                               threshold=threshold),
+        stop_by_no_improvement(
+            extractor=extractor, metric_name=metric_name, early_stop=early_stop, threshold=threshold
+        ),
         stop_by_iter_num(iter_limit=iter_limit),
-        stop_by_num_features(min_num_features=min_remaining_features))
+        stop_by_num_features(min_num_features=min_remaining_features),
+    )
 
     train_fn = lambda df: param_train_fn(df, features)
     first_logs = parallel_validator(train_data, split_fn, train_fn, eval_fn, n_jobs=n_jobs)
@@ -121,138 +139,140 @@ def feature_importance_backward_selection(train_data: pd.DataFrame,
     return logs
 
 
-def poor_man_boruta_selection(train_data: pd.DataFrame,
-                              test_data: pd.DataFrame,
-                              param_train_fn: TuningLearnerFnType,
-                              features: List[str],
-                              eval_fn: EvalFnType,
-                              extractor: ExtractorFnType,
-                              metric_name: str,
-                              max_removed_by_step: int = 5,
-                              threshold: float = 0.005,
-                              early_stop: int = 2,
-                              iter_limit: int = 50,
-                              min_remaining_features: int = 50,
-                              save_intermediary_fn: Callable[[LogType], None] = None,
-                              speed_up_by_importance: bool = False,
-                              parallel: bool = False,
-                              nthread: int = 1,
-                              seed: int = 7) -> LogListType:
+def poor_man_boruta_selection(
+    train_data: pd.DataFrame,
+    test_data: pd.DataFrame,
+    param_train_fn: TuningLearnerFnType,
+    features: List[str],
+    eval_fn: EvalFnType,
+    extractor: ExtractorFnType,
+    metric_name: str,
+    max_removed_by_step: int = 5,
+    threshold: float = 0.005,
+    early_stop: int = 2,
+    iter_limit: int = 50,
+    min_remaining_features: int = 50,
+    save_intermediary_fn: Callable[[LogType], None] = None,
+    speed_up_by_importance: bool = False,
+    parallel: bool = False,
+    nthread: int = 1,
+    seed: int = 7,
+) -> LogListType:
     """
-        Performs train-evaluation iterations while shuffiling the used features
-        to compute statistics about feature relevance
+    Performs train-evaluation iterations while shuffiling the used features
+    to compute statistics about feature relevance
 
-        Parameters
-        ----------
-        train_data : pandas.DataFrame
-            A Pandas' DataFrame with training data
+    Parameters
+    ----------
+    train_data : pandas.DataFrame
+        A Pandas' DataFrame with training data
 
-        test_data : pandas.DataFrame
-            A Pandas' DataFrame with test data
+    test_data : pandas.DataFrame
+        A Pandas' DataFrame with test data
 
-        param_train_fn : function (pandas.DataFrame, list of str) -> prediction_function, predictions_dataset, logs
-            A partially defined AND curried learning function that takes a training set and a feature list and
-            returns a predict function, a dataset with training predictions and training
-            logs.
+    param_train_fn : function (pandas.DataFrame, list of str) -> prediction_function, predictions_dataset, logs
+        A partially defined AND curried learning function that takes a training set and a feature list and
+        returns a predict function, a dataset with training predictions and training
+        logs.
 
-        features: list of str
-            Elements must be columns of the train_data
+    features: list of str
+        Elements must be columns of the train_data
 
-        eval_fn : function pandas.DataFrame -> dict
-            A partially defined evaluation function that takes a dataset with prediction and
-            returns the evaluation logs.
+    eval_fn : function pandas.DataFrame -> dict
+        A partially defined evaluation function that takes a dataset with prediction and
+        returns the evaluation logs.
 
-        extractor: function str -> float
-            A extractor that take a string and returns the value of that string on a dict
+    extractor: function str -> float
+        A extractor that take a string and returns the value of that string on a dict
 
-        metric_name: str
-            String with the name of the column that refers to the metric column to be extracted
+    metric_name: str
+        String with the name of the column that refers to the metric column to be extracted
 
-        max_removed_by_step: int (default 5)
-            The maximum number of features to remove. It will only consider the least max_removed_by_step in terms of
-            feature importance. If speed_up_by_importance=True it will first filter the least relevant feature an
-            shuffle only those. If speed_up_by_importance=False it will shuffle all features and drop the last
-            max_removed_by_step in terms of PIMP. In both cases, the features will only be removed if drop in
-            performance is up to the defined threshold.
+    max_removed_by_step: int (default 5)
+        The maximum number of features to remove. It will only consider the least max_removed_by_step in terms of
+        feature importance. If speed_up_by_importance=True it will first filter the least relevant feature an
+        shuffle only those. If speed_up_by_importance=False it will shuffle all features and drop the last
+        max_removed_by_step in terms of PIMP. In both cases, the features will only be removed if drop in
+        performance is up to the defined threshold.
 
-        threshold: float (default 0.005)
-            Threshold for model performance comparison
+    threshold: float (default 0.005)
+        Threshold for model performance comparison
 
-        early_stop: int (default 2)
-            Number of rounds without improvement before stopping process
+    early_stop: int (default 2)
+        Number of rounds without improvement before stopping process
 
-        iter_limit: int (default 50)
-            Maximum number of iterations before stopping
+    iter_limit: int (default 50)
+        Maximum number of iterations before stopping
 
-        min_remaining_features: int (default 50)
-            Minimum number of features that should remain in the model,
-            combining num_removed_by_step and iter_limit accomplishes the same
-            functionality as this parameter.
+    min_remaining_features: int (default 50)
+        Minimum number of features that should remain in the model,
+        combining num_removed_by_step and iter_limit accomplishes the same
+        functionality as this parameter.
 
-        save_intermediary_fn: function(log) -> save to file
-            Partially defined saver function that receives a log result from a
-            tuning step and appends it into a file
-            Example: save_intermediary_result(save_path='tuning.pkl')
+    save_intermediary_fn: function(log) -> save to file
+        Partially defined saver function that receives a log result from a
+        tuning step and appends it into a file
+        Example: save_intermediary_result(save_path='tuning.pkl')
 
-        speed_up_by_importance: bool (default True)
-            If it should narrow search looking at feature importance first before getting PIMP importance. If True,
-            will only shuffle the top num_removed_by_step in terms of feature importance.
+    speed_up_by_importance: bool (default True)
+        If it should narrow search looking at feature importance first before getting PIMP importance. If True,
+        will only shuffle the top num_removed_by_step in terms of feature importance.
 
-        max_removed_by_step: int (default 50)
-            If speed_up_by_importance=False, this will limit the number of features dropped by iteration. It will only
-            drop the max_removed_by_step features that decrease the metric by the least when dropped.
+    max_removed_by_step: int (default 50)
+        If speed_up_by_importance=False, this will limit the number of features dropped by iteration. It will only
+        drop the max_removed_by_step features that decrease the metric by the least when dropped.
 
-        parallel: bool (default False)
-            Run shuffling and prediction in parallel. Only applies if speed_up_by_importance=False
+    parallel: bool (default False)
+        Run shuffling and prediction in parallel. Only applies if speed_up_by_importance=False
 
-        nthread: int (default 1)
-            Number of threads to run predictions. ONly applied if speed_up_by_importance=False
+    nthread: int (default 1)
+        Number of threads to run predictions. ONly applied if speed_up_by_importance=False
 
-        seed: int (default 7)
-            random state for consistency.
+    seed: int (default 7)
+        random state for consistency.
 
 
-        Returns
-        ----------
-        logs: list of list of dict
-            A list log-like lists of dictionaries evaluations. Each element of the
-            list is validation step of the algorithm.
+    Returns
+    ----------
+    logs: list of list of dict
+        A list log-like lists of dictionaries evaluations. Each element of the
+        list is validation step of the algorithm.
 
     """
 
-    selector_fn = remove_by_feature_shuffling(eval_fn=eval_fn,
-                                              eval_data=test_data,
-                                              extractor=extractor,
-                                              metric_name=metric_name,
-                                              max_removed_by_step=max_removed_by_step,
-                                              threshold=threshold,
-                                              speed_up_by_importance=speed_up_by_importance,
-                                              parallel=parallel,
-                                              nthread=nthread,
-                                              seed=seed)
+    selector_fn = remove_by_feature_shuffling(
+        eval_fn=eval_fn,
+        eval_data=test_data,
+        extractor=extractor,
+        metric_name=metric_name,
+        max_removed_by_step=max_removed_by_step,
+        threshold=threshold,
+        speed_up_by_importance=speed_up_by_importance,
+        parallel=parallel,
+        nthread=nthread,
+        seed=seed,
+    )
 
     stop_fn = aggregate_stop_funcs(
-        stop_by_no_improvement(extractor=extractor, metric_name=metric_name, early_stop=early_stop,
-                               threshold=threshold),
+        stop_by_no_improvement(
+            extractor=extractor, metric_name=metric_name, early_stop=early_stop, threshold=threshold
+        ),
         stop_by_iter_num(iter_limit=iter_limit),
-        stop_by_num_features(min_num_features=min_remaining_features)
+        stop_by_num_features(min_num_features=min_remaining_features),
     )
 
     predict_fn_first, _, train_logs = param_train_fn(train_data, features)
     eval_logs = eval_fn(predict_fn_first(test_data))
 
     first_logs = {
-        'train_log': train_logs,
-        'validator_log': [
+        "train_log": train_logs,
+        "validator_log": [
             {
-                'fold_num': 0,
-                'split_log': {
-                    'train_size': train_data.shape[0],
-                    'test_size': test_data.shape[0]
-                },
-                'eval_results': [eval_logs]
+                "fold_num": 0,
+                "split_log": {"train_size": train_data.shape[0], "test_size": test_data.shape[0]},
+                "eval_results": [eval_logs],
             }
-        ]
+        ],
     }
 
     logs = [first_logs]
@@ -267,9 +287,16 @@ def poor_man_boruta_selection(train_data: pd.DataFrame,
         next_predict_fn, _, next_train_logs = param_train_fn(train_data, next_features)
 
         eval_logs = pipe(test_data, next_predict_fn, eval_fn)
-        next_log = {'train_log': next_train_logs, 'validator_log': [
-            {'fold_num': 0, 'split_log': {'train_size': train_data.shape[0], 'test_size': test_data.shape[0]},
-             'eval_results': [eval_logs]}]}
+        next_log = {
+            "train_log": next_train_logs,
+            "validator_log": [
+                {
+                    "fold_num": 0,
+                    "split_log": {"train_size": train_data.shape[0], "test_size": test_data.shape[0]},
+                    "eval_results": [eval_logs],
+                }
+            ],
+        }
 
         logs = [next_log] + logs
 
@@ -281,97 +308,101 @@ def poor_man_boruta_selection(train_data: pd.DataFrame,
     return logs
 
 
-def backward_subset_feature_selection(train_data: pd.DataFrame,
-                                      param_train_fn: TuningLearnerFnType,
-                                      features_sets: Dict[str, List[str]],
-                                      split_fn: SplitterFnType,
-                                      eval_fn: EvalFnType,
-                                      extractor: ExtractorFnType,
-                                      metric_name: str,
-                                      threshold: float = 0.005,
-                                      num_removed_by_step: int = 3,
-                                      early_stop: int = 2,
-                                      iter_limit: int = 50,
-                                      min_remaining_features: int = 50,
-                                      save_intermediary_fn: SaveIntermediaryFnType = None,
-                                      n_jobs: int = 1) -> ListLogListType:
+def backward_subset_feature_selection(
+    train_data: pd.DataFrame,
+    param_train_fn: TuningLearnerFnType,
+    features_sets: Dict[str, List[str]],
+    split_fn: SplitterFnType,
+    eval_fn: EvalFnType,
+    extractor: ExtractorFnType,
+    metric_name: str,
+    threshold: float = 0.005,
+    num_removed_by_step: int = 3,
+    early_stop: int = 2,
+    iter_limit: int = 50,
+    min_remaining_features: int = 50,
+    save_intermediary_fn: SaveIntermediaryFnType = None,
+    n_jobs: int = 1,
+) -> ListLogListType:
     """
-        Performs train-evaluation iterations while testing the subsets of features
-        to compute statistics about the importance of each feature category
+    Performs train-evaluation iterations while testing the subsets of features
+    to compute statistics about the importance of each feature category
 
-        Parameters
-        ----------
-        train_data : pandas.DataFrame
-            A Pandas' DataFrame with training data
+    Parameters
+    ----------
+    train_data : pandas.DataFrame
+        A Pandas' DataFrame with training data
 
-        param_train_fn : function (pandas.DataFrame, list of str) -> prediction_function, predictions_dataset, logs
-            A partially defined learning function that takes a training set and a feature list and
-            returns a predict function, a dataset with training predictions and training
-            logs.
+    param_train_fn : function (pandas.DataFrame, list of str) -> prediction_function, predictions_dataset, logs
+        A partially defined learning function that takes a training set and a feature list and
+        returns a predict function, a dataset with training predictions and training
+        logs.
 
-        features_sets: dict of string -> list
-            Each String Key on the dict is a subset of columns from the dataset, the function will
-            analyse the influence of each group of features on the model performance
+    features_sets: dict of string -> list
+        Each String Key on the dict is a subset of columns from the dataset, the function will
+        analyse the influence of each group of features on the model performance
 
-        split_fn : function pandas.DataFrame ->  list of tuple
-            Partially defined split function that takes a dataset and returns
-            a list of folds. Each fold is a Tuple of arrays. The fist array in
-            each tuple contains training indexes while the second array
-            contains validation indexes.
+    split_fn : function pandas.DataFrame ->  list of tuple
+        Partially defined split function that takes a dataset and returns
+        a list of folds. Each fold is a Tuple of arrays. The fist array in
+        each tuple contains training indexes while the second array
+        contains validation indexes.
 
-        eval_fn : function pandas.DataFrame -> dict
-            A partially defined evaluation function that takes a dataset with prediction and
-            returns the evaluation logs.
+    eval_fn : function pandas.DataFrame -> dict
+        A partially defined evaluation function that takes a dataset with prediction and
+        returns the evaluation logs.
 
-        extractor: function str -> float
-            A extractor that take a string and returns the value of that string on a dict
+    extractor: function str -> float
+        A extractor that take a string and returns the value of that string on a dict
 
-        metric_name: str
-            String with the name of the column that refers to the metric column to be extracted
+    metric_name: str
+        String with the name of the column that refers to the metric column to be extracted
 
-        num_removed_by_step: int (default 3)
-            Number of features removed at each iteration
+    num_removed_by_step: int (default 3)
+        Number of features removed at each iteration
 
-        threshold: float (default 0.005)
-            Threshold for model performance comparison
+    threshold: float (default 0.005)
+        Threshold for model performance comparison
 
-        early_stop: int (default 2)
-            Number of rounds without improvement before stopping process
+    early_stop: int (default 2)
+        Number of rounds without improvement before stopping process
 
-        iter_limit: int (default 50)
-            Maximum number of iterations before stopping
+    iter_limit: int (default 50)
+        Maximum number of iterations before stopping
 
-        min_remaining_features: int (default 50)
-            Minimum number of features that should remain in the model,
-            combining num_removed_by_step and iter_limit accomplishes the same
-            functionality as this parameter.
+    min_remaining_features: int (default 50)
+        Minimum number of features that should remain in the model,
+        combining num_removed_by_step and iter_limit accomplishes the same
+        functionality as this parameter.
 
-        save_intermediary_fn : function(log) -> save to file
-            Partially defined saver function that receives a log result from a
-            tuning step and appends it into a file
-            Example: save_intermediary_result(save_path='tuning.pkl')
+    save_intermediary_fn : function(log) -> save to file
+        Partially defined saver function that receives a log result from a
+        tuning step and appends it into a file
+        Example: save_intermediary_result(save_path='tuning.pkl')
 
-        n_jobs : int
-            Number of parallel processes to spawn.
+    n_jobs : int
+        Number of parallel processes to spawn.
 
-        Returns
-        ----------
-        logs: list of list of dict
-            A list log-like lists of dictionaries evaluations. Each element of the
-            list is validation step of the algorithm.
+    Returns
+    ----------
+    logs: list of list of dict
+        A list log-like lists of dictionaries evaluations. Each element of the
+        list is validation step of the algorithm.
 
     """
 
-    selector_fn = remove_features_subsets(extractor=extractor,
-                                          metric_name=metric_name,
-                                          num_removed_by_step=num_removed_by_step)
+    selector_fn = remove_features_subsets(
+        extractor=extractor, metric_name=metric_name, num_removed_by_step=num_removed_by_step
+    )
 
     stop_fn = aggregate_stop_funcs(
-        stop_by_no_improvement_parallel(extractor=extractor, metric_name=metric_name, early_stop=early_stop,
-                                        threshold=threshold),
+        stop_by_no_improvement_parallel(
+            extractor=extractor, metric_name=metric_name, early_stop=early_stop, threshold=threshold
+        ),
         stop_by_iter_num(iter_limit=iter_limit),
-        stop_by_num_features_parallel(extractor=extractor, metric_name=metric_name,
-                                      min_num_features=min_remaining_features)
+        stop_by_num_features_parallel(
+            extractor=extractor, metric_name=metric_name, min_num_features=min_remaining_features
+        ),
     )
 
     used_subsets = [features_sets.keys()]

--- a/src/fklearn/tuning/stoppers.py
+++ b/src/fklearn/tuning/stoppers.py
@@ -31,34 +31,31 @@ def aggregate_stop_funcs(*stop_funcs: StopFnType) -> StopFnType:
 
 
 @curry
-def stop_by_iter_num(logs: ListLogListType,
-                     iter_limit: int = 50) -> bool:
+def stop_by_iter_num(logs: ListLogListType, iter_limit: int = 50) -> bool:
     """
-        Checks for logs to see if feature selection should stop
+    Checks for logs to see if feature selection should stop
 
-        Parameters
-        ----------
-        logs : list of list of dict
-            A list of log-like lists of dictionaries evaluations.
+    Parameters
+    ----------
+    logs : list of list of dict
+        A list of log-like lists of dictionaries evaluations.
 
-        iter_limit: int (default 50)
-            Limit of Iterations
+    iter_limit: int (default 50)
+        Limit of Iterations
 
-        Returns
-        ----------
-        stop: bool
-            A boolean whether to stop recursion or not
+    Returns
+    ----------
+    stop: bool
+        A boolean whether to stop recursion or not
     """
 
     return len(logs) >= iter_limit
 
 
 @curry
-def stop_by_no_improvement(logs: ListLogListType,
-                           extractor: ExtractorFnType,
-                           metric_name: str,
-                           early_stop: int = 3,
-                           threshold: float = 0.001) -> bool:
+def stop_by_no_improvement(
+    logs: ListLogListType, extractor: ExtractorFnType, metric_name: str, early_stop: int = 3, threshold: float = 0.001
+) -> bool:
     """
     Checks for logs to see if feature selection should stop
 
@@ -92,17 +89,17 @@ def stop_by_no_improvement(logs: ListLogListType,
     curr_auc = get_avg_metric_from_extractor(limited_logs[-1], extractor, metric_name)
 
     return all(
-        [(curr_auc - get_avg_metric_from_extractor(log, extractor, metric_name)) <= threshold
-         for log in limited_logs[:-1]]
+        [
+            (curr_auc - get_avg_metric_from_extractor(log, extractor, metric_name)) <= threshold
+            for log in limited_logs[:-1]
+        ]
     )
 
 
 @curry
-def stop_by_no_improvement_parallel(logs: ListLogListType,
-                                    extractor: ExtractorFnType,
-                                    metric_name: str,
-                                    early_stop: int = 3,
-                                    threshold: float = 0.001) -> bool:
+def stop_by_no_improvement_parallel(
+    logs: ListLogListType, extractor: ExtractorFnType, metric_name: str, early_stop: int = 3, threshold: float = 0.001
+) -> bool:
     """
     Checks for logs to see if feature selection should stop
 
@@ -138,13 +135,15 @@ def stop_by_no_improvement_parallel(logs: ListLogListType,
     curr_auc = get_avg_metric_from_extractor(limited_logs[-1], extractor, metric_name)
 
     return all(
-        [(curr_auc - get_avg_metric_from_extractor(log, extractor, metric_name)) <= threshold
-         for log in limited_logs[:-1]])
+        [
+            (curr_auc - get_avg_metric_from_extractor(log, extractor, metric_name)) <= threshold
+            for log in limited_logs[:-1]
+        ]
+    )
 
 
 @curry
-def stop_by_num_features(logs: ListLogListType,
-                         min_num_features: int = 50) -> bool:
+def stop_by_num_features(logs: ListLogListType, min_num_features: int = 50) -> bool:
     """
     Checks for logs to see if feature selection should stop
 
@@ -166,10 +165,9 @@ def stop_by_num_features(logs: ListLogListType,
 
 
 @curry
-def stop_by_num_features_parallel(logs: ListLogListType,
-                                  extractor: ExtractorFnType,
-                                  metric_name: str,
-                                  min_num_features: int = 50) -> bool:
+def stop_by_num_features_parallel(
+    logs: ListLogListType, extractor: ExtractorFnType, metric_name: str, min_num_features: int = 50
+) -> bool:
     """
     Selects the best log out of a list to see if feature selection should stop
 

--- a/src/fklearn/tuning/utils.py
+++ b/src/fklearn/tuning/utils.py
@@ -18,11 +18,11 @@ def get_best_performing_log(log_list: LogListType, extractor: ExtractorFnType, m
 
 
 def get_used_features(log: Dict) -> List[str]:
-    return first((gen_dict_extract('features', log)))
+    return first((gen_dict_extract("features", log)))
 
 
 def order_feature_importance_avg_from_logs(log: Dict) -> List[str]:
-    d = first(gen_dict_extract('feature_importance', log))
+    d = first(gen_dict_extract("feature_importance", log))
     return sorted(d, key=d.get, reverse=True)
 
 
@@ -40,7 +40,7 @@ def gen_key_avgs_from_dicts(obj: List) -> Dict[str, float]:
 
 
 def gen_dict_extract(key: str, obj: Dict) -> Generator[Any, None, None]:
-    if hasattr(obj, 'items'):
+    if hasattr(obj, "items"):
         for k, v in obj.items():
             if k == key:
                 yield v
@@ -55,5 +55,6 @@ def gen_dict_extract(key: str, obj: Dict) -> Generator[Any, None, None]:
 
 @curry
 def gen_validator_log(eval_log: EvalReturnType, fold_num: int, test_size: int) -> ValidatorReturnType:
-    return {'validator_log': [{'fold_num': fold_num, 'split_log': {'test_size': test_size},
-                               'eval_results': [eval_log]}]}
+    return {
+        "validator_log": [{"fold_num": fold_num, "split_log": {"test_size": test_size}, "eval_results": [eval_log]}]
+    }

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -245,6 +245,7 @@ def precision_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
+    
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -244,8 +244,8 @@ def recall_evaluator(
     eval_name: str = None,
     **kwargs,
 ) -> EvalReturnType:
-   """
-    Computes the precision score, given true label and prediction scores.
+    """
+    Computes the recall score, given true label and prediction scores.
     Parameters
     ----------
     test_data : pandas.DataFrame
@@ -266,9 +266,11 @@ def recall_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
-    eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
+
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
     binned = pd.cut(test_data[prediction_column], bins, labels=labels)
+
+    eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
 
     eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -5,16 +5,23 @@ import numpy as np
 import pandas as pd
 import toolz as fp
 from pandas.util import hash_pandas_object
-from sklearn.metrics import (average_precision_score, brier_score_loss,
-                             fbeta_score, log_loss, mean_absolute_error,
-                             mean_squared_error, precision_score, r2_score,
-                             recall_score, roc_auc_score)
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    fbeta_score,
+    log_loss,
+    mean_absolute_error,
+    mean_squared_error,
+    precision_score,
+    r2_score,
+    recall_score,
+    roc_auc_score,
+)
 from toolz import curry, last, first
 from scipy import optimize
 from sklearn.linear_model import LogisticRegression
 
-from fklearn.types import (EvalFnType, EvalReturnType, PredictFnType,
-                           UncurriedEvalFnType)
+from fklearn.types import EvalFnType, EvalReturnType, PredictFnType, UncurriedEvalFnType
 
 
 def generic_sklearn_evaluator(name_prefix: str, sklearn_metric: Callable[..., float]) -> UncurriedEvalFnType:
@@ -35,17 +42,21 @@ def generic_sklearn_evaluator(name_prefix: str, sklearn_metric: Callable[..., fl
        An evaluator function that uses the provided metric
     """
 
-    def p(test_data: pd.DataFrame,
-          prediction_column: str = "prediction",
-          target_column: str = "target",
-          weight_column: str = None,
-          eval_name: str = None,
-          **kwargs: Any) -> EvalReturnType:
+    def p(
+        test_data: pd.DataFrame,
+        prediction_column: str = "prediction",
+        target_column: str = "target",
+        weight_column: str = None,
+        eval_name: str = None,
+        **kwargs: Any,
+    ) -> EvalReturnType:
         try:
-            score = sklearn_metric(test_data[target_column],
-                                   test_data[prediction_column],
-                                   sample_weight=None if weight_column is None else test_data[weight_column],
-                                   **kwargs)
+            score = sklearn_metric(
+                test_data[target_column],
+                test_data[prediction_column],
+                sample_weight=None if weight_column is None else test_data[weight_column],
+                **kwargs,
+            )
         except ValueError:
             # this might happen if there's only one class in the fold
             score = np.nan
@@ -59,11 +70,13 @@ def generic_sklearn_evaluator(name_prefix: str, sklearn_metric: Callable[..., fl
 
 
 @curry
-def auc_evaluator(test_data: pd.DataFrame,
-                  prediction_column: str = "prediction",
-                  target_column: str = "target",
-                  weight_column: str = None,
-                  eval_name: str = None) -> EvalReturnType:
+def auc_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the ROC AUC score, given true label and prediction scores.
 
@@ -90,19 +103,23 @@ def auc_evaluator(test_data: pd.DataFrame,
         A log-like dictionary with the ROC AUC Score
     """
 
-    warnings.warn("The method `auc_evaluator` will be renamed to `roc_auc_evaluator` in the next major release 2.0.0."
-                  " Please use `roc_auc_evaluator` instead of `auc_evaluator` for Area Under the Curve of the"
-                  " Receiver Operating Characteristics curve.")
+    warnings.warn(
+        "The method `auc_evaluator` will be renamed to `roc_auc_evaluator` in the next major release 2.0.0."
+        " Please use `roc_auc_evaluator` instead of `auc_evaluator` for Area Under the Curve of the"
+        " Receiver Operating Characteristics curve."
+    )
 
     return roc_auc_evaluator(test_data, prediction_column, target_column, weight_column, eval_name)
 
 
 @curry
-def roc_auc_evaluator(test_data: pd.DataFrame,
-                      prediction_column: str = "prediction",
-                      target_column: str = "target",
-                      weight_column: str = None,
-                      eval_name: str = None) -> EvalReturnType:
+def roc_auc_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the ROC AUC score, given true label and prediction scores.
 
@@ -136,11 +153,13 @@ def roc_auc_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def pr_auc_evaluator(test_data: pd.DataFrame,
-                     prediction_column: str = "prediction",
-                     target_column: str = "target",
-                     weight_column: str = None,
-                     eval_name: str = None) -> EvalReturnType:
+def pr_auc_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the PR AUC score, given true label and prediction scores.
 
@@ -173,14 +192,16 @@ def pr_auc_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def precision_evaluator(test_data: pd.DataFrame,                        
-                        threshold: Iterable[float] = [0.5],
-                        labels: Iterable[int] = [0,1],
-                        prediction_column: str = "prediction",
-                        target_column: str = "target",
-                        weight_column: str = None,
-                        eval_name: str = None,                        
-                        **kwargs) -> EvalReturnType:
+def precision_evaluator(
+    test_data: pd.DataFrame,
+    threshold: Iterable[float] = [0.5],
+    labels: Iterable[int] = [0, 1],
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+    **kwargs,
+) -> EvalReturnType:
     """
     Computes the precision score, given true label and prediction scores.
 
@@ -212,13 +233,13 @@ def precision_evaluator(test_data: pd.DataFrame,
             The class to report if average='binary' and the data is binary.
 
         average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-            This parameter is required for multiclass/multilabel targets. 
+            This parameter is required for multiclass/multilabel targets.
 
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
         zero_division : “warn”, 0 or 1, default=”warn”
-            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.    
+            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
 
     Returns
     ----------
@@ -226,24 +247,26 @@ def precision_evaluator(test_data: pd.DataFrame,
         A log-like dictionary with the Precision Score
     """
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
-    
+
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
     binned = pd.cut(test_data[prediction_column], bins, labels=labels)
-    
-    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})   
+
+    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})
 
     return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 
 
 @curry
-def recall_evaluator(test_data: pd.DataFrame,
-                     threshold: Iterable[float] = [0.5],
-                     labels: Iterable[int] = [0,1],
-                     prediction_column: str = "prediction",
-                     target_column: str = "target",
-                     weight_column: str = None,
-                     eval_name: str = None,
-                     **kwargs) -> EvalReturnType:
+def recall_evaluator(
+    test_data: pd.DataFrame,
+    threshold: Iterable[float] = [0.5],
+    labels: Iterable[int] = [0, 1],
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+    **kwargs,
+) -> EvalReturnType:
     """
     Computes the recall score, given true label and prediction scores.
 
@@ -258,7 +281,7 @@ def recall_evaluator(test_data: pd.DataFrame,
 
     labels: Array[int] (default=[0,1])
         A list of labels for the classes obtained using the threshold list above.
-    
+
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
 
@@ -276,14 +299,14 @@ def recall_evaluator(test_data: pd.DataFrame,
             The class to report if average='binary' and the data is binary.
 
         average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-            This parameter is required for multiclass/multilabel targets. 
+            This parameter is required for multiclass/multilabel targets.
 
         sample_weight : array-like of shape (n_samples,), default=None
             Sample weights.
 
         zero_division : “warn”, 0 or 1, default=”warn”
-            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.    
-    
+            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
+
     Returns
     ----------
     log: dict
@@ -294,20 +317,22 @@ def recall_evaluator(test_data: pd.DataFrame,
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
     binned = pd.cut(test_data[prediction_column], bins, labels=labels)
-    
-    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})   
+
+    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})
 
     return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 
 
 @curry
-def fbeta_score_evaluator(test_data: pd.DataFrame,
-                          threshold: float = 0.5,
-                          beta: float = 1.0,
-                          prediction_column: str = "prediction",
-                          target_column: str = "target",
-                          weight_column: str = None,
-                          eval_name: str = None) -> EvalReturnType:
+def fbeta_score_evaluator(
+    test_data: pd.DataFrame,
+    threshold: float = 0.5,
+    beta: float = 1.0,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the F-beta score, given true label and prediction scores.
 
@@ -351,11 +376,13 @@ def fbeta_score_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def logloss_evaluator(test_data: pd.DataFrame,
-                      prediction_column: str = "prediction",
-                      target_column: str = "target",
-                      weight_column: str = None,
-                      eval_name: str = None) -> EvalReturnType:
+def logloss_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the logloss score, given true label and prediction scores.
 
@@ -389,11 +416,13 @@ def logloss_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def brier_score_evaluator(test_data: pd.DataFrame,
-                          prediction_column: str = "prediction",
-                          target_column: str = "target",
-                          weight_column: str = None,
-                          eval_name: str = None) -> EvalReturnType:
+def brier_score_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the Brier score, given true label and prediction scores.
 
@@ -427,12 +456,14 @@ def brier_score_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def expected_calibration_error_evaluator(test_data: pd.DataFrame,
-                                         prediction_column: str = "prediction",
-                                         target_column: str = "target",
-                                         eval_name: str = None,
-                                         n_bins: int = 100,
-                                         bin_choice: str = "count") -> EvalReturnType:
+def expected_calibration_error_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    eval_name: str = None,
+    n_bins: int = 100,
+    bin_choice: str = "count",
+) -> EvalReturnType:
     """
     Computes the expected calibration error (ECE), given true label and prediction scores.
     See "On Calibration of Modern Neural Networks"(https://arxiv.org/abs/1706.04599) for more information.
@@ -501,9 +532,9 @@ def expected_calibration_error_evaluator(test_data: pd.DataFrame,
     else:
         raise AttributeError("Invalid bin_choice")
 
-    metric_df = pd.DataFrame({"bins": bins,
-                              "predictions": test_data[prediction_column],
-                              "actuals": test_data[target_column]})
+    metric_df = pd.DataFrame(
+        {"bins": bins, "predictions": test_data[prediction_column], "actuals": test_data[target_column]}
+    )
 
     agg_df = metric_df.groupby("bins").agg({"bins": "count", "predictions": "mean", "actuals": "mean"})
 
@@ -517,11 +548,13 @@ def expected_calibration_error_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def r2_evaluator(test_data: pd.DataFrame,
-                 prediction_column: str = "prediction",
-                 target_column: str = "target",
-                 weight_column: str = None,
-                 eval_name: str = None) -> EvalReturnType:
+def r2_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the R2 score, given true label and predictions.
 
@@ -554,11 +587,13 @@ def r2_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def mse_evaluator(test_data: pd.DataFrame,
-                  prediction_column: str = "prediction",
-                  target_column: str = "target",
-                  weight_column: str = None,
-                  eval_name: str = None) -> EvalReturnType:
+def mse_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    weight_column: str = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the Mean Squared Error, given true label and predictions.
 
@@ -590,9 +625,9 @@ def mse_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def mean_prediction_evaluator(test_data: pd.DataFrame,
-                              prediction_column: str = "prediction",
-                              eval_name: str = None) -> EvalReturnType:
+def mean_prediction_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes mean for the specified column.
 
@@ -614,16 +649,15 @@ def mean_prediction_evaluator(test_data: pd.DataFrame,
     """
 
     if eval_name is None:
-        eval_name = 'mean_evaluator__' + prediction_column
+        eval_name = "mean_evaluator__" + prediction_column
 
     return {eval_name: test_data[prediction_column].mean()}
 
 
 @curry
-def correlation_evaluator(test_data: pd.DataFrame,
-                          prediction_column: str = "prediction",
-                          target_column: str = "target",
-                          eval_name: str = None) -> EvalReturnType:
+def correlation_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", target_column: str = "target", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes the Pearson correlation between prediction and target.
 
@@ -655,10 +689,9 @@ def correlation_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def linear_coefficient_evaluator(test_data: pd.DataFrame,
-                                 prediction_column: str = "prediction",
-                                 target_column: str = "target",
-                                 eval_name: str = None) -> EvalReturnType:
+def linear_coefficient_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", target_column: str = "target", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes the linear coefficient from regressing the outcome on the prediction
 
@@ -691,10 +724,9 @@ def linear_coefficient_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def spearman_evaluator(test_data: pd.DataFrame,
-                       prediction_column: str = "prediction",
-                       target_column: str = "target",
-                       eval_name: str = None) -> EvalReturnType:
+def spearman_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", target_column: str = "target", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes the Spearman correlation between prediction and target.
     The Spearman correlation evaluates the rank order between two variables:
@@ -728,12 +760,14 @@ def spearman_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def ndcg_evaluator(test_data: pd.DataFrame,
-                   prediction_column: str = "prediction",
-                   target_column: str = "target",
-                   k: int = None,
-                   exponential_gain: bool = True,
-                   eval_name: str = None) -> EvalReturnType:
+def ndcg_evaluator(
+    test_data: pd.DataFrame,
+    prediction_column: str = "prediction",
+    target_column: str = "target",
+    k: int = None,
+    exponential_gain: bool = True,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Computes the Normalized Discount Cumulative Gain (NDCG) between
     of the original and predicted rankings:
@@ -781,8 +815,8 @@ def ndcg_evaluator(test_data: pd.DataFrame,
     ideal_cum_gain = np.sort(test_data[target_column])[::-1][:k]
 
     if exponential_gain:
-        cum_gain = (2 ** cum_gain) - 1
-        ideal_cum_gain = (2 ** ideal_cum_gain) - 1
+        cum_gain = (2**cum_gain) - 1
+        ideal_cum_gain = (2**ideal_cum_gain) - 1
 
     discount = np.log2(np.arange(len(cum_gain)) + 2.0)
 
@@ -795,8 +829,7 @@ def ndcg_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def combined_evaluators(test_data: pd.DataFrame,
-                        evaluators: List[EvalFnType]) -> EvalReturnType:
+def combined_evaluators(test_data: pd.DataFrame, evaluators: List[EvalFnType]) -> EvalReturnType:
     """
     Combine partially applies evaluation functions.
 
@@ -817,11 +850,9 @@ def combined_evaluators(test_data: pd.DataFrame,
 
 
 @curry
-def split_evaluator(test_data: pd.DataFrame,
-                    eval_fn: EvalFnType,
-                    split_col: str,
-                    split_values: Iterable = None,
-                    eval_name: str = None) -> EvalReturnType:
+def split_evaluator(
+    test_data: pd.DataFrame, eval_fn: EvalFnType, split_col: str, split_values: Iterable = None, eval_name: str = None
+) -> EvalReturnType:
     """
     Splits the dataset into the categories in `split_col` and evaluate
     model performance in each split. Useful when you belive the model
@@ -854,19 +885,23 @@ def split_evaluator(test_data: pd.DataFrame,
         split_values = test_data[split_col].unique()
 
     if eval_name is None:
-        eval_name = 'split_evaluator__' + split_col
+        eval_name = "split_evaluator__" + split_col
 
-    return {eval_name + "_" + str(value): eval_fn(test_data.loc[lambda df: df[split_col] == value])
-            for value in split_values}
+    return {
+        eval_name + "_" + str(value): eval_fn(test_data.loc[lambda df: df[split_col] == value])
+        for value in split_values
+    }
 
 
 @curry
-def temporal_split_evaluator(test_data: pd.DataFrame,
-                             eval_fn: EvalFnType,
-                             time_col: str,
-                             time_format: str = "%Y-%m",
-                             split_values: Iterable[str] = None,
-                             eval_name: str = None) -> EvalReturnType:
+def temporal_split_evaluator(
+    test_data: pd.DataFrame,
+    eval_fn: EvalFnType,
+    time_col: str,
+    time_format: str = "%Y-%m",
+    split_values: Iterable[str] = None,
+    eval_name: str = None,
+) -> EvalReturnType:
     """
     Splits the dataset into the temporal categories by `time_col` and evaluate
     model performance in each split.
@@ -905,26 +940,30 @@ def temporal_split_evaluator(test_data: pd.DataFrame,
     unique_values = formatted_time_col.unique()
 
     if eval_name is None:
-        eval_name = 'split_evaluator__' + time_col
+        eval_name = "split_evaluator__" + time_col
 
     if split_values is None:
         split_values = unique_values
     else:
         if not (all(sv in unique_values for sv in split_values)):
-            raise ValueError('All split values must be present in the column (after date formatting it')
+            raise ValueError("All split values must be present in the column (after date formatting it")
 
-    return {eval_name + "_" + str(value): eval_fn(test_data.loc[lambda df: formatted_time_col == value])
-            for value in split_values}
+    return {
+        eval_name + "_" + str(value): eval_fn(test_data.loc[lambda df: formatted_time_col == value])
+        for value in split_values
+    }
 
 
 @curry
-def permutation_evaluator(test_data: pd.DataFrame,
-                          predict_fn: PredictFnType,
-                          eval_fn: EvalFnType,
-                          baseline: bool = True,
-                          features: List[str] = None,
-                          shuffle_all_at_once: bool = False,
-                          random_state: int = None) -> EvalReturnType:
+def permutation_evaluator(
+    test_data: pd.DataFrame,
+    predict_fn: PredictFnType,
+    eval_fn: EvalFnType,
+    baseline: bool = True,
+    features: List[str] = None,
+    shuffle_all_at_once: bool = False,
+    random_state: int = None,
+) -> EvalReturnType:
     """
     Permutation importance evaluator.
     It works by shuffling one or more features on test_data dataframe,
@@ -975,14 +1014,14 @@ def permutation_evaluator(test_data: pd.DataFrame,
         return eval_fn(predict_fn(test_data.assign(**shuffled_cols)))
 
     if shuffle_all_at_once:
-        permutation_results = {'-'.join(features): permutation_eval(features)}
+        permutation_results = {"-".join(features): permutation_eval(features)}
     else:
         permutation_results = {f: permutation_eval([f]) for f in features}
 
-    feature_importance = {'permutation_importance': permutation_results}
+    feature_importance = {"permutation_importance": permutation_results}
 
     if baseline:
-        baseline_results = {'permutation_importance_baseline': eval_fn(predict_fn(test_data))}
+        baseline_results = {"permutation_importance_baseline": eval_fn(predict_fn(test_data))}
     else:
         baseline_results = {}
 
@@ -990,10 +1029,9 @@ def permutation_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def hash_evaluator(test_data: pd.DataFrame,
-                   hash_columns: List[str] = None,
-                   eval_name: str = None,
-                   consider_index: bool = False) -> EvalReturnType:
+def hash_evaluator(
+    test_data: pd.DataFrame, hash_columns: List[str] = None, eval_name: str = None, consider_index: bool = False
+) -> EvalReturnType:
     """
     Computes the hash of a pandas dataframe, filtered by hash columns. The
     purpose is to uniquely identify a dataframe, to be able to check if two
@@ -1039,10 +1077,9 @@ def hash_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def exponential_coefficient_evaluator(test_data: pd.DataFrame,
-                                      prediction_column: str = "prediction",
-                                      target_column: str = "target",
-                                      eval_name: str = None) -> EvalReturnType:
+def exponential_coefficient_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", target_column: str = "target", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes the exponential coefficient between prediction and target. Finds a1 in the following equation
     target = exp(a0 + a1 prediction)
@@ -1070,16 +1107,20 @@ def exponential_coefficient_evaluator(test_data: pd.DataFrame,
     if eval_name is None:
         eval_name = "exponential_coefficient_evaluator__" + target_column
 
-    score = last(first(optimize.curve_fit(lambda t, a0, a1: a0 * np.exp(a1 * t),
-                                          test_data[prediction_column], test_data[target_column])))
+    score = last(
+        first(
+            optimize.curve_fit(
+                lambda t, a0, a1: a0 * np.exp(a1 * t), test_data[prediction_column], test_data[target_column]
+            )
+        )
+    )
     return {eval_name: score}
 
 
 @curry
-def logistic_coefficient_evaluator(test_data: pd.DataFrame,
-                                   prediction_column: str = "prediction",
-                                   target_column: str = "target",
-                                   eval_name: str = None) -> EvalReturnType:
+def logistic_coefficient_evaluator(
+    test_data: pd.DataFrame, prediction_column: str = "prediction", target_column: str = "target", eval_name: str = None
+) -> EvalReturnType:
     """
     Computes the logistic coefficient between prediction and target. Finds a1 in the following equation
     target = logistic(a0 + a1 prediction)
@@ -1107,7 +1148,10 @@ def logistic_coefficient_evaluator(test_data: pd.DataFrame,
     if eval_name is None:
         eval_name = "logistic_coefficient_evaluator__" + target_column
 
-    score = LogisticRegression(penalty="none", multi_class="ovr").fit(test_data[[prediction_column]],
-                                                                      test_data[target_column]).coef_[0][0]
+    score = (
+        LogisticRegression(penalty="none", multi_class="ovr")
+        .fit(test_data[[prediction_column]], test_data[target_column])
+        .coef_[0][0]
+    )
 
     return {eval_name: score}

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -199,7 +199,7 @@ def precision_evaluator(
     target_column: str = "target",
     weight_column: str = None,
     eval_name: str = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> EvalReturnType:
     """
     Computes the precision score, given true label and prediction scores.
@@ -245,7 +245,7 @@ def recall_evaluator(
     target_column: str = "target",
     weight_column: str = None,
     eval_name: str = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> EvalReturnType:
     """
     Computes the recall score, given true label and prediction scores.

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -224,6 +224,7 @@ def precision_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
+    
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
@@ -267,6 +268,7 @@ def recall_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
+    
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -473,7 +473,6 @@ def expected_calibration_error_evaluator(
     log: dict
        A log-like dictionary with the expected calibration error.
     """
-
     if eval_name is None:
         eval_name = "expected_calibration_error_evaluator__" + target_column
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -208,7 +208,7 @@ def precision_evaluator(
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
     threshold : Array[float] (default=[0.5])
-        A list of thresholds for the prediction column, to the bin is given 
+        A list of thresholds for the prediction column, to the bin is given
         the corresponding label in the parameter label
     labels : Array(int) (default=[0,1])
         A list of labels to be used by the binning
@@ -221,17 +221,17 @@ def precision_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
     pos_label : str or int, (default=1)
-        The class to report if average='binary' and the data is binary. 
+        The class to report if average='binary' and the data is binary.
         If the data are multiclass or multilabel, this will be ignored.
     average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-        This parameter is required for multiclass/multilabel targets. 
-        If None, the scores for each class are returned as a list, 
+        This parameter is required for multiclass/multilabel targets.
+        If None, the scores for each class are returned as a list,
         but the type is not supported by sheep anymore.
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
     zero_division : “warn”, 0 or 1, default=”warn”
-        Sets the value to return when there is a zero division. 
-        If set to “warn”, this acts as 0, but warnings are also raised.        
+        Sets the value to return when there is a zero division.
+        If set to “warn”, this acts as 0, but warnings are also raised.
     Returns
     ----------
     log: dict
@@ -265,7 +265,7 @@ def recall_evaluator(
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
     threshold : Array[float] (default=[0.5])
-        A list of thresholds for the prediction column, to the bin is given 
+        A list of thresholds for the prediction column, to the bin is given
         the corresponding label in the parameter label
     labels : Array(int) (default=[0,1])
         A list of labels to be used by the binning
@@ -278,23 +278,22 @@ def recall_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
     pos_label : str or int, (default=1)
-        The class to report if average='binary' and the data is binary. 
+        The class to report if average='binary' and the data is binary.
         If the data are multiclass or multilabel, this will be ignored.
     average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-        This parameter is required for multiclass/multilabel targets. 
-        If None, the scores for each class are returned as a list, 
+        This parameter is required for multiclass/multilabel targets.
+        If None, the scores for each class are returned as a list,
         but the type is not supported by sheep anymore.
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
     zero_division : “warn”, 0 or 1, default=”warn”
-        Sets the value to return when there is a zero division. 
-        If set to “warn”, this acts as 0, but warnings are also raised.        
+        Sets the value to return when there is a zero division.
+        If set to “warn”, this acts as 0, but warnings are also raised.
     Returns
     ----------
     log: dict
         A log-like dictionary with the Recall Score
     """
-
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
     binned = pd.cut(test_data[prediction_column], bins, labels=labels)
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -207,12 +207,11 @@ def precision_evaluator(
     ----------
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
-    threshold : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
-    labels : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
+    threshold : Array[float] (default=[0.5])
+        A list of thresholds for the prediction column, to the bin is given 
+        the corresponding label in the parameter label
+    labels : Array(int) (default=[0,1])
+        A list of labels to be used by the binning
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
     target_column : str
@@ -221,6 +220,18 @@ def precision_evaluator(
         The name of the column in `test_data` with the sample weights.
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
+    pos_label : str or int, (default=1)
+        The class to report if average='binary' and the data is binary. 
+        If the data are multiclass or multilabel, this will be ignored.
+    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+        This parameter is required for multiclass/multilabel targets. 
+        If None, the scores for each class are returned as a list, 
+        but the type is not supported by sheep anymore.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+    zero_division : “warn”, 0 or 1, default=”warn”
+        Sets the value to return when there is a zero division. 
+        If set to “warn”, this acts as 0, but warnings are also raised.        
     Returns
     ----------
     log: dict
@@ -253,12 +264,11 @@ def recall_evaluator(
     ----------
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
-    threshold : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
-    labels : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
+    threshold : Array[float] (default=[0.5])
+        A list of thresholds for the prediction column, to the bin is given 
+        the corresponding label in the parameter label
+    labels : Array(int) (default=[0,1])
+        A list of labels to be used by the binning
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
     target_column : str
@@ -267,10 +277,22 @@ def recall_evaluator(
         The name of the column in `test_data` with the sample weights.
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
+    pos_label : str or int, (default=1)
+        The class to report if average='binary' and the data is binary. 
+        If the data are multiclass or multilabel, this will be ignored.
+    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+        This parameter is required for multiclass/multilabel targets. 
+        If None, the scores for each class are returned as a list, 
+        but the type is not supported by sheep anymore.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+    zero_division : “warn”, 0 or 1, default=”warn”
+        Sets the value to return when there is a zero division. 
+        If set to “warn”, this acts as 0, but warnings are also raised.        
     Returns
     ----------
     log: dict
-        A log-like dictionary with the Precision Score
+        A log-like dictionary with the Recall Score
     """
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -189,9 +189,11 @@ def precision_evaluator(test_data: pd.DataFrame,
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
 
-    threshold : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
+    threshold : Array[float] (default=[0.5])
+        A list of thresholds for the prediction column above, the class for which interval is defined by the parametre labels.
+
+    labels: Array[int] (default=[0,1])
+        A list of labels for the classes obtained using the threshold list above.
 
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
@@ -204,6 +206,19 @@ def precision_evaluator(test_data: pd.DataFrame,
 
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
+
+    **kwargs:
+        pos_label : str or int, default=1
+            The class to report if average='binary' and the data is binary.
+
+        average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+            This parameter is required for multiclass/multilabel targets. 
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+
+        zero_division : “warn”, 0 or 1, default=”warn”
+            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.    
 
     Returns
     ----------
@@ -238,10 +253,12 @@ def recall_evaluator(test_data: pd.DataFrame,
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
 
-    threshold : float
-        A threshold for the prediction column above which samples
-         will be classified as 1
+    threshold : Array[float] (default=[0.5])
+        A list of thresholds for the prediction column above, the class for which interval is defined by the parametre labels.
 
+    labels: Array[int] (default=[0,1])
+        A list of labels for the classes obtained using the threshold list above.
+    
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
 
@@ -254,6 +271,19 @@ def recall_evaluator(test_data: pd.DataFrame,
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
 
+    **kwargs:
+        pos_label : str or int, default=1
+            The class to report if average='binary' and the data is binary.
+
+        average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+            This parameter is required for multiclass/multilabel targets. 
+
+        sample_weight : array-like of shape (n_samples,), default=None
+            Sample weights.
+
+        zero_division : “warn”, 0 or 1, default=”warn”
+            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.    
+    
     Returns
     ----------
     log: dict

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -173,12 +173,13 @@ def pr_auc_evaluator(test_data: pd.DataFrame,
 
 
 @curry
-def precision_evaluator(test_data: pd.DataFrame,
-                        threshold: float = 0.5,
+def precision_evaluator(test_data: pd.DataFrame,                        
+                        threshold: Iterable[float] = [0.5],
+                        labels: Iterable[int] = [0,1],
                         prediction_column: str = "prediction",
                         target_column: str = "target",
                         weight_column: str = None,
-                        eval_name: str = None,
+                        eval_name: str = None,                        
                         **kwargs) -> EvalReturnType:
     """
     Computes the precision score, given true label and prediction scores.
@@ -210,14 +211,19 @@ def precision_evaluator(test_data: pd.DataFrame,
         A log-like dictionary with the Precision Score
     """
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
-    eval_data = test_data.assign(**{prediction_column: (test_data[prediction_column] > threshold).astype(int)})
+    
+    bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
+    binned = pd.cut(test_data[prediction_column], bins, labels=labels)
+    
+    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})   
 
     return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 
 
 @curry
 def recall_evaluator(test_data: pd.DataFrame,
-                     threshold: float = 0.5,
+                     threshold: Iterable[float] = [0.5],
+                     labels: Iterable[int] = [0,1],
                      prediction_column: str = "prediction",
                      target_column: str = "target",
                      weight_column: str = None,
@@ -254,8 +260,12 @@ def recall_evaluator(test_data: pd.DataFrame,
         A log-like dictionary with the Precision Score
     """
 
-    eval_data = test_data.assign(**{prediction_column: (test_data[prediction_column] > threshold).astype(int)})
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
+
+    bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
+    binned = pd.cut(test_data[prediction_column], bins, labels=labels)
+    
+    eval_data = test_data.assign(**{prediction_column: (binned).astype(int)})   
 
     return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -220,7 +220,7 @@ def precision_evaluator(
     weight_column : String (default=None)
         The name of the column in `test_data` with the sample weights.
     eval_name : str, optional (default=None)
-        the name of the evaluator as it will appear in the logs.    
+        the name of the evaluator as it will appear in the logs.
     Returns
     ----------
     log: dict

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -184,7 +184,6 @@ def pr_auc_evaluator(
     ----------
     A log-like dictionary with the PR AUC Score
     """
-
     eval_fn = generic_sklearn_evaluator("pr_auc_evaluator__", average_precision_score)
     eval_data = test_data.assign(**{target_column: lambda df: df[target_column].astype(int)})
 
@@ -224,7 +223,6 @@ def precision_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
-    
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -210,6 +210,9 @@ def precision_evaluator(
     threshold : float
         A threshold for the prediction column above which samples
          will be classified as 1
+    labels : float
+        A threshold for the prediction column above which samples
+         will be classified as 1
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
     target_column : str
@@ -217,7 +220,7 @@ def precision_evaluator(
     weight_column : String (default=None)
         The name of the column in `test_data` with the sample weights.
     eval_name : str, optional (default=None)
-        the name of the evaluator as it will appear in the logs.
+        the name of the evaluator as it will appear in the logs.    
     Returns
     ----------
     log: dict
@@ -251,6 +254,9 @@ def recall_evaluator(
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
     threshold : float
+        A threshold for the prediction column above which samples
+         will be classified as 1
+    labels : float
         A threshold for the prediction column above which samples
          will be classified as 1
     prediction_column : str

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -266,7 +266,6 @@ def recall_evaluator(
     log: dict
         A log-like dictionary with the Precision Score
     """
-    
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
@@ -402,7 +401,6 @@ def brier_score_evaluator(
     log: dict
         A log-like dictionary with the Brier score.
     """
-
     eval_fn = generic_sklearn_evaluator("brier_score_evaluator__", brier_score_loss)
     eval_data = test_data.assign(**{target_column: lambda df: df[target_column].astype(int)})
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -204,48 +204,26 @@ def precision_evaluator(
 ) -> EvalReturnType:
     """
     Computes the precision score, given true label and prediction scores.
-
     Parameters
     ----------
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
-
-    threshold : Array[float] (default=[0.5])
-        A list of thresholds for the prediction column above, the class for which interval is defined by the parametre labels.
-
-    labels: Array[int] (default=[0,1])
-        A list of labels for the classes obtained using the threshold list above.
-
+    threshold : float
+        A threshold for the prediction column above which samples
+         will be classified as 1
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
-
     target_column : str
         The name of the column in `test_data` with the binary target.
-
     weight_column : String (default=None)
         The name of the column in `test_data` with the sample weights.
-
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
-
-    pos_label : str or int, default=1
-        The class to report if average='binary' and the data is binary.
-
-    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-        This parameter is required for multiclass/multilabel targets.
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : “warn”, 0 or 1, default=”warn”
-        Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
-
     Returns
     ----------
     log: dict
         A log-like dictionary with the Precision Score
     """
-    
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
@@ -267,51 +245,28 @@ def recall_evaluator(
     eval_name: str = None,
     **kwargs,
 ) -> EvalReturnType:
-    """
-    Computes the recall score, given true label and prediction scores.
-
+   """
+    Computes the precision score, given true label and prediction scores.
     Parameters
     ----------
-
     test_data : pandas.DataFrame
         A Pandas' DataFrame with target and prediction scores.
-
-    threshold : Array[float] (default=[0.5])
-        A list of thresholds for the prediction column above, the class for which interval is defined by the parametre labels.
-
-    labels: Array[int] (default=[0,1])
-        A list of labels for the classes obtained using the threshold list above.
-
+    threshold : float
+        A threshold for the prediction column above which samples
+         will be classified as 1
     prediction_column : str
         The name of the column in `test_data` with the prediction scores.
-
     target_column : str
         The name of the column in `test_data` with the binary target.
-
     weight_column : String (default=None)
         The name of the column in `test_data` with the sample weights.
-
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
-
-    pos_label : str or int, default=1
-        The class to report if average='binary' and the data is binary.
-
-    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-        This parameter is required for multiclass/multilabel targets.
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : “warn”, 0 or 1, default=”warn”
-        Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
-
     Returns
     ----------
     log: dict
         A log-like dictionary with the Precision Score
     """
-
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
 
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -228,18 +228,18 @@ def precision_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
 
-    **kwargs:
-        pos_label : str or int, default=1
-            The class to report if average='binary' and the data is binary.
+    **kwargs 
+    pos_label : str or int, default=1
+        The class to report if average='binary' and the data is binary.
 
-        average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-            This parameter is required for multiclass/multilabel targets.
+    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+        This parameter is required for multiclass/multilabel targets.
 
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
 
-        zero_division : “warn”, 0 or 1, default=”warn”
-            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
+    zero_division : “warn”, 0 or 1, default=”warn”
+        Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
 
     Returns
     ----------
@@ -294,18 +294,18 @@ def recall_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
 
-    **kwargs:
-        pos_label : str or int, default=1
-            The class to report if average='binary' and the data is binary.
+    **kwargs 
+    pos_label : str or int, default=1
+        The class to report if average='binary' and the data is binary.
 
-        average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
-            This parameter is required for multiclass/multilabel targets.
+    average : {‘micro’, ‘macro’, ‘samples’, ‘weighted’, ‘binary’} or None, default=’binary’
+        This parameter is required for multiclass/multilabel targets.
 
-        sample_weight : array-like of shape (n_samples,), default=None
-            Sample weights.
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
 
-        zero_division : “warn”, 0 or 1, default=”warn”
-            Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
+    zero_division : “warn”, 0 or 1, default=”warn”
+        Sets the value to return when there is a zero division. If set to “warn”, this acts as 0, but warnings are also raised.
 
     Returns
     ----------

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -228,7 +228,6 @@ def precision_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
 
-    **kwargs 
     pos_label : str or int, default=1
         The class to report if average='binary' and the data is binary.
 
@@ -294,7 +293,6 @@ def recall_evaluator(
     eval_name : str, optional (default=None)
         the name of the evaluator as it will appear in the logs.
 
-    **kwargs 
     pos_label : str or int, default=1
         The class to report if average='binary' and the data is binary.
 

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -178,7 +178,8 @@ def precision_evaluator(test_data: pd.DataFrame,
                         prediction_column: str = "prediction",
                         target_column: str = "target",
                         weight_column: str = None,
-                        eval_name: str = None) -> EvalReturnType:
+                        eval_name: str = None,
+                        **kwargs) -> EvalReturnType:
     """
     Computes the precision score, given true label and prediction scores.
 
@@ -211,7 +212,7 @@ def precision_evaluator(test_data: pd.DataFrame,
     eval_fn = generic_sklearn_evaluator("precision_evaluator__", precision_score)
     eval_data = test_data.assign(**{prediction_column: (test_data[prediction_column] > threshold).astype(int)})
 
-    return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name)
+    return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 
 
 @curry
@@ -220,7 +221,8 @@ def recall_evaluator(test_data: pd.DataFrame,
                      prediction_column: str = "prediction",
                      target_column: str = "target",
                      weight_column: str = None,
-                     eval_name: str = None) -> EvalReturnType:
+                     eval_name: str = None,
+                     **kwargs) -> EvalReturnType:
     """
     Computes the recall score, given true label and prediction scores.
 
@@ -255,7 +257,7 @@ def recall_evaluator(test_data: pd.DataFrame,
     eval_data = test_data.assign(**{prediction_column: (test_data[prediction_column] > threshold).astype(int)})
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
 
-    return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name)
+    return eval_fn(eval_data, prediction_column, target_column, weight_column, eval_name, **kwargs)
 
 
 @curry

--- a/src/fklearn/validation/evaluators.py
+++ b/src/fklearn/validation/evaluators.py
@@ -267,7 +267,6 @@ def recall_evaluator(
         A log-like dictionary with the Precision Score
     """
     eval_fn = generic_sklearn_evaluator("recall_evaluator__", recall_score)
-
     bins = pd.concat([pd.Series(-np.inf), pd.Series(threshold), pd.Series(np.inf)])
     binned = pd.cut(test_data[prediction_column], bins, labels=labels)
 

--- a/src/fklearn/validation/perturbators.py
+++ b/src/fklearn/validation/perturbators.py
@@ -99,9 +99,7 @@ def sample_columns(data: pd.DataFrame, perc: float) -> List[str]:
 
 
 @curry
-def perturbator(data: pd.DataFrame,
-                cols: List[str],
-                corruption_fn: ColumnWisePerturbFnType) -> pd.DataFrame:
+def perturbator(data: pd.DataFrame, cols: List[str], corruption_fn: ColumnWisePerturbFnType) -> pd.DataFrame:
     """
     transforms specific columns of a dataset according to an artificial
     corruption function.

--- a/src/fklearn/validation/splitters.py
+++ b/src/fklearn/validation/splitters.py
@@ -15,41 +15,57 @@ from fklearn.types import DateType, LogType, SplitterReturnType
 
 def _log_time_fold(time_fold: Tuple[pd.Series, pd.Series]) -> LogType:
     train_time, test_time = time_fold
-    return {"train_start": train_time.min(), "train_end": train_time.max(), "train_size": train_time.shape[0],
-            "test_start": test_time.min(), "test_end": test_time.max(), "test_size": test_time.shape[0]}
+    return {
+        "train_start": train_time.min(),
+        "train_end": train_time.max(),
+        "train_size": train_time.shape[0],
+        "test_start": test_time.min(),
+        "test_end": test_time.max(),
+        "test_size": test_time.shape[0],
+    }
 
 
-def _get_lc_folds(date_range: Union[pd.DatetimeIndex, pd.PeriodIndex],
-                  date_fold_filter_fn: Callable[[DateType], pd.DataFrame],
-                  test_time: pd.Series,
-                  time_column: str,
-                  min_samples: int) -> List[Tuple[pd.Series, pd.Series]]:
-    return pipe(date_range,
-                map(date_fold_filter_fn),  # iteratively filter the dates
-                map(lambda df: df[time_column]),  # keep only time column
-                filter(lambda s: len(s.index) > min_samples),
-                lambda train: zip(train, repeat(test_time)),
-                list)
+def _get_lc_folds(
+    date_range: Union[pd.DatetimeIndex, pd.PeriodIndex],
+    date_fold_filter_fn: Callable[[DateType], pd.DataFrame],
+    test_time: pd.Series,
+    time_column: str,
+    min_samples: int,
+) -> List[Tuple[pd.Series, pd.Series]]:
+    return pipe(
+        date_range,
+        map(date_fold_filter_fn),  # iteratively filter the dates
+        map(lambda df: df[time_column]),  # keep only time column
+        filter(lambda s: len(s.index) > min_samples),
+        lambda train: zip(train, repeat(test_time)),
+        list,
+    )
 
 
-def _get_sc_folds(date_range: Union[pd.DatetimeIndex, pd.PeriodIndex],
-                  date_fold_filter_fn: Callable[[DateType], pd.DataFrame],
-                  time_column: str,
-                  min_samples: int) -> List[Tuple[pd.Series, pd.Series]]:
-    return pipe(date_range,
-                map(date_fold_filter_fn),  # iteratively filter the dates
-                map(lambda df: df[time_column]),  # keep only time column
-                filter(lambda s: len(s.index) > min_samples),
-                list)
+def _get_sc_folds(
+    date_range: Union[pd.DatetimeIndex, pd.PeriodIndex],
+    date_fold_filter_fn: Callable[[DateType], pd.DataFrame],
+    time_column: str,
+    min_samples: int,
+) -> List[Tuple[pd.Series, pd.Series]]:
+    return pipe(
+        date_range,
+        map(date_fold_filter_fn),  # iteratively filter the dates
+        map(lambda df: df[time_column]),  # keep only time column
+        filter(lambda s: len(s.index) > min_samples),
+        list,
+    )
 
 
-def _get_sc_test_fold_idx_and_logs(test_data: pd.DataFrame,
-                                   train_time: pd.Series,
-                                   time_column: str,
-                                   first_test_moment: DateType,
-                                   last_test_moment: DateType,
-                                   min_samples: int,
-                                   freq: str) -> Tuple[List[LogType], List[List[pd.Index]]]:
+def _get_sc_test_fold_idx_and_logs(
+    test_data: pd.DataFrame,
+    train_time: pd.Series,
+    time_column: str,
+    first_test_moment: DateType,
+    last_test_moment: DateType,
+    min_samples: int,
+    freq: str,
+) -> Tuple[List[LogType], List[List[pd.Index]]]:
     periods_range = pd.period_range(start=first_test_moment, end=last_test_moment, freq=freq)
 
     def date_filter_fn(period: DateType) -> pd.DataFrame:
@@ -67,10 +83,9 @@ def _lc_fold_to_indexes(folds: List[Tuple[pd.Series, pd.Series]]) -> List[Tuple[
 
 
 @curry
-def k_fold_splitter(train_data: pd.DataFrame,
-                    n_splits: int,
-                    random_state: int = None,
-                    stratify_column: str = None) -> SplitterReturnType:
+def k_fold_splitter(
+    train_data: pd.DataFrame, n_splits: int, random_state: int = None, stratify_column: str = None
+) -> SplitterReturnType:
     """
     Makes K random train/test split folds for cross validation.
     The folds are made so that every sample is used at least once for
@@ -94,8 +109,9 @@ def k_fold_splitter(train_data: pd.DataFrame,
     """
 
     if stratify_column is not None:
-        folds = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state) \
-            .split(train_data, train_data[stratify_column])
+        folds = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state).split(
+            train_data, train_data[stratify_column]
+        )
     else:
         folds = KFold(n_splits, shuffle=True, random_state=random_state).split(train_data)
     result = list(map(lambda f: (f[0], [f[1]]), folds))
@@ -112,12 +128,14 @@ k_fold_splitter.__doc__ += splitter_return_docstring
 # train_indexes will have time_column <= in_time_limit
 # test_indexes will have time_column > in_time_limit
 @curry
-def out_of_time_and_space_splitter(train_data: pd.DataFrame,
-                                   n_splits: int,
-                                   in_time_limit: DateType,
-                                   time_column: str,
-                                   space_column: str,
-                                   holdout_gap: timedelta = timedelta(days=0)) -> SplitterReturnType:
+def out_of_time_and_space_splitter(
+    train_data: pd.DataFrame,
+    n_splits: int,
+    in_time_limit: DateType,
+    time_column: str,
+    space_column: str,
+    holdout_gap: timedelta = timedelta(days=0),
+) -> SplitterReturnType:
     """
     Makes K grouped train/test split folds for cross validation.
     The folds are made so that every ID is used at least once for
@@ -157,12 +175,21 @@ def out_of_time_and_space_splitter(train_data: pd.DataFrame,
 
     # train_indexes have time_column <= in_time_limit
     # test_indexes have time_column > in_time_limit
-    folds = pipe(space_folds,
-                 partial(starmap, lambda f_train, f_test: [train_data.iloc[f_train][time_column],
-                                                           train_data.iloc[f_test][time_column]]),
-                 partial(starmap, lambda train, test: (train[train <= in_time_limit],  # filter train time
-                                                       test[test > (in_time_limit + holdout_gap)])),  # filter test time
-                 list)
+    folds = pipe(
+        space_folds,
+        partial(
+            starmap,
+            lambda f_train, f_test: [train_data.iloc[f_train][time_column], train_data.iloc[f_test][time_column]],
+        ),
+        partial(
+            starmap,
+            lambda train, test: (
+                train[train <= in_time_limit],  # filter train time
+                test[test > (in_time_limit + holdout_gap)],
+            ),
+        ),  # filter test time
+        list,
+    )
 
     logs = list(map(_log_time_fold, folds))  # get fold logs
     folds_indexes = _lc_fold_to_indexes(folds)  # final formatting with idx
@@ -173,15 +200,17 @@ out_of_time_and_space_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def time_and_space_learning_curve_splitter(train_data: pd.DataFrame,
-                                           training_time_limit: str,
-                                           space_column: str,
-                                           time_column: str,
-                                           freq: str = 'M',
-                                           space_hold_percentage: float = 0.5,
-                                           holdout_gap: timedelta = timedelta(days=0),
-                                           random_state: int = None,
-                                           min_samples: int = 1000) -> SplitterReturnType:
+def time_and_space_learning_curve_splitter(
+    train_data: pd.DataFrame,
+    training_time_limit: str,
+    space_column: str,
+    time_column: str,
+    freq: str = "M",
+    space_hold_percentage: float = 0.5,
+    holdout_gap: timedelta = timedelta(days=0),
+    random_state: int = None,
+    min_samples: int = 1000,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
     Uses a fixed out-of-ID and time hold out set for every fold.
@@ -228,11 +257,13 @@ def time_and_space_learning_curve_splitter(train_data: pd.DataFrame,
 
     # sklearn function that handles int or object random states, turns them into a rng
     rng = check_random_state(random_state)
-    out_of_space_mask = pipe(train_data,
-                             lambda df: df[df[time_column] > date_range[-1]],  # filter out of time
-                             lambda df: df[space_column].unique(),  # get unique space
-                             lambda array: rng.choice(array, int(len(array) * space_hold_percentage), replace=False),
-                             lambda held_space: train_data[space_column].isin(held_space))  # filter out of space
+    out_of_space_mask = pipe(
+        train_data,
+        lambda df: df[df[time_column] > date_range[-1]],  # filter out of time
+        lambda df: df[space_column].unique(),  # get unique space
+        lambda array: rng.choice(array, int(len(array) * space_hold_percentage), replace=False),
+        lambda held_space: train_data[space_column].isin(held_space),
+    )  # filter out of space
 
     training_time_limit_dt = datetime.strptime(training_time_limit, "%Y-%m-%d") + holdout_gap
     test_time = train_data[(train_data[time_column] > training_time_limit_dt) & out_of_space_mask][time_column]
@@ -252,12 +283,14 @@ time_and_space_learning_curve_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def time_learning_curve_splitter(train_data: pd.DataFrame,
-                                 training_time_limit: DateType,
-                                 time_column: str,
-                                 freq: str = 'M',
-                                 holdout_gap: timedelta = timedelta(days=0),
-                                 min_samples: int = 1000) -> SplitterReturnType:
+def time_learning_curve_splitter(
+    train_data: pd.DataFrame,
+    training_time_limit: DateType,
+    time_column: str,
+    freq: str = "M",
+    holdout_gap: timedelta = timedelta(days=0),
+    min_samples: int = 1000,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
 
@@ -312,13 +345,15 @@ time_learning_curve_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def reverse_time_learning_curve_splitter(train_data: pd.DataFrame,
-                                         time_column: str,
-                                         training_time_limit: DateType,
-                                         lower_time_limit: DateType = None,
-                                         freq: str = 'MS',
-                                         holdout_gap: timedelta = timedelta(days=0),
-                                         min_samples: int = 1000) -> SplitterReturnType:
+def reverse_time_learning_curve_splitter(
+    train_data: pd.DataFrame,
+    time_column: str,
+    training_time_limit: DateType,
+    lower_time_limit: DateType = None,
+    freq: str = "MS",
+    holdout_gap: timedelta = timedelta(days=0),
+    min_samples: int = 1000,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
     Uses a fixed out-of-ID and time hold out set for every fold.
@@ -378,13 +413,15 @@ reverse_time_learning_curve_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def spatial_learning_curve_splitter(train_data: pd.DataFrame,
-                                    space_column: str,
-                                    time_column: str,
-                                    training_limit: DateType,
-                                    holdout_gap: timedelta = timedelta(days=0),
-                                    train_percentages: Iterable[float] = (0.25, 0.5, 0.75, 1.0),
-                                    random_state: int = None) -> SplitterReturnType:
+def spatial_learning_curve_splitter(
+    train_data: pd.DataFrame,
+    space_column: str,
+    time_column: str,
+    training_limit: DateType,
+    holdout_gap: timedelta = timedelta(days=0),
+    train_percentages: Iterable[float] = (0.25, 0.5, 0.75, 1.0),
+    random_state: int = None,
+) -> SplitterReturnType:
     """
     Splits the data for a spatial learning curve. Progressively adds more and
     more examples to the training in order to verify the impact of having more
@@ -423,17 +460,17 @@ def spatial_learning_curve_splitter(train_data: pd.DataFrame,
         A seed for the random number generator that shuffles the IDs.
     """
     if np.min(train_percentages) < 0 or np.max(train_percentages) > 1:
-        raise ValueError('Train percentages must be between 0 and 1')
+        raise ValueError("Train percentages must be between 0 and 1")
 
     if isinstance(training_limit, str):
         training_limit = datetime.strptime(training_limit, "%Y-%m-%d")
 
     if training_limit < train_data[time_column].min() or training_limit > train_data[time_column].max():
-        raise ValueError('Temporal training limit should be within datasets temporal bounds (min and max times)')
+        raise ValueError("Temporal training limit should be within datasets temporal bounds (min and max times)")
     if timedelta(days=0) > holdout_gap:
-        raise ValueError('Holdout gap cannot be negative')
+        raise ValueError("Holdout gap cannot be negative")
     if holdout_gap >= (train_data[time_column].max() - training_limit):
-        raise ValueError('After taking the gap into account, there should be enough time for the holdout set')
+        raise ValueError("After taking the gap into account, there should be enough time for the holdout set")
 
     train_data = train_data.reset_index()
 
@@ -446,14 +483,16 @@ def spatial_learning_curve_splitter(train_data: pd.DataFrame,
         lambda idx: np.split(spatial_ids, idx)[:-1],  # Split spatial ids by the indices
         lambda l: map(lambda x: x.tolist(), l),  # Transform sub-arrays into sub-lists
         lambda l: filter(None, l),  # Drop empty sub-lists
-        accumulate(operator.add)  # Cumulative sum of lists
+        accumulate(operator.add),  # Cumulative sum of lists
     )
 
     validation_set = train_data[train_data[time_column] > (training_limit + holdout_gap)]
     train_data = train_data[train_data[time_column] <= training_limit]
 
-    folds = [(train_data[train_data[space_column].isin(ids)][time_column], validation_set[time_column])
-             for ids in cumulative_ids]
+    folds = [
+        (train_data[train_data[space_column].isin(ids)][time_column], validation_set[time_column])
+        for ids in cumulative_ids
+    ]
 
     folds_indices = _lc_fold_to_indexes(folds)  # final formatting with idx
 
@@ -466,11 +505,9 @@ spatial_learning_curve_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def stability_curve_time_splitter(train_data: pd.DataFrame,
-                                  training_time_limit: DateType,
-                                  time_column: str,
-                                  freq: str = 'M',
-                                  min_samples: int = 1000) -> SplitterReturnType:
+def stability_curve_time_splitter(
+    train_data: pd.DataFrame, training_time_limit: DateType, time_column: str, freq: str = "M", min_samples: int = 1000
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
     Training set is fixed before hold out and uses a rolling window hold out set.
@@ -506,8 +543,9 @@ def stability_curve_time_splitter(train_data: pd.DataFrame,
     first_test_moment = test_data[time_column].min()
     last_test_moment = test_data[time_column].max()
 
-    logs, test_indexes = _get_sc_test_fold_idx_and_logs(test_data, train_time, time_column, first_test_moment,
-                                                        last_test_moment, min_samples, freq)
+    logs, test_indexes = _get_sc_test_fold_idx_and_logs(
+        test_data, train_time, time_column, first_test_moment, last_test_moment, min_samples, freq
+    )
 
     # From "list of dicts" to "dict of lists" hack:
     logs = [{k: [dic[k] for dic in logs] for k in logs[0]}]
@@ -522,14 +560,16 @@ stability_curve_time_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def stability_curve_time_in_space_splitter(train_data: pd.DataFrame,
-                                           training_time_limit: DateType,
-                                           space_column: str,
-                                           time_column: str,
-                                           freq: str = 'M',
-                                           space_hold_percentage: float = 0.5,
-                                           random_state: int = None,
-                                           min_samples: int = 1000) -> SplitterReturnType:
+def stability_curve_time_in_space_splitter(
+    train_data: pd.DataFrame,
+    training_time_limit: DateType,
+    space_column: str,
+    time_column: str,
+    freq: str = "M",
+    space_hold_percentage: float = 0.5,
+    random_state: int = None,
+    min_samples: int = 1000,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
     Training set is fixed before hold out and uses a rolling window hold out set.
@@ -574,17 +614,21 @@ def stability_curve_time_in_space_splitter(train_data: pd.DataFrame,
 
     train_time = train_data[train_data[time_column] <= training_time_limit][time_column]
 
-    test_data = pipe(train_data,
-                     lambda trand_df: trand_df.iloc[train_time.index][space_column].unique(),
-                     lambda space: rng.choice(space, int(len(space) * space_hold_percentage), replace=False),
-                     lambda held_space: train_data[(train_data[time_column] > training_time_limit)
-                                                   & (train_data[space_column].isin(held_space))])
+    test_data = pipe(
+        train_data,
+        lambda trand_df: trand_df.iloc[train_time.index][space_column].unique(),
+        lambda space: rng.choice(space, int(len(space) * space_hold_percentage), replace=False),
+        lambda held_space: train_data[
+            (train_data[time_column] > training_time_limit) & (train_data[space_column].isin(held_space))
+        ],
+    )
 
     first_test_moment = test_data[time_column].min()
     last_test_moment = test_data[time_column].max()
 
-    logs, test_indexes = _get_sc_test_fold_idx_and_logs(test_data, train_time, time_column, first_test_moment,
-                                                        last_test_moment, min_samples, freq)
+    logs, test_indexes = _get_sc_test_fold_idx_and_logs(
+        test_data, train_time, time_column, first_test_moment, last_test_moment, min_samples, freq
+    )
 
     # From "list of dicts" to "dict of lists" hack:
     logs = [{k: [dic[k] for dic in logs] for k in logs[0]}]
@@ -599,14 +643,16 @@ stability_curve_time_in_space_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def stability_curve_time_space_splitter(train_data: pd.DataFrame,
-                                        training_time_limit: DateType,
-                                        space_column: str,
-                                        time_column: str,
-                                        freq: str = 'M',
-                                        space_hold_percentage: float = 0.5,
-                                        random_state: int = None,
-                                        min_samples: int = 1000) -> SplitterReturnType:
+def stability_curve_time_space_splitter(
+    train_data: pd.DataFrame,
+    training_time_limit: DateType,
+    space_column: str,
+    time_column: str,
+    freq: str = "M",
+    space_hold_percentage: float = 0.5,
+    random_state: int = None,
+    min_samples: int = 1000,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets given by the specified frequency.
     Training set is fixed before hold out and uses a rolling window hold out set.
@@ -655,15 +701,18 @@ def stability_curve_time_space_splitter(train_data: pd.DataFrame,
     held_space = rng.choice(train_space, int(len(train_space) * space_hold_percentage), replace=False)
 
     test_data = train_data[
-        (train_data[time_column] > training_time_limit) & (~train_data[space_column].isin(held_space))]
+        (train_data[time_column] > training_time_limit) & (~train_data[space_column].isin(held_space))
+    ]
     train_index = train_data[
-        (train_data[time_column] <= training_time_limit) & (train_data[space_column].isin(held_space))].index.values
+        (train_data[time_column] <= training_time_limit) & (train_data[space_column].isin(held_space))
+    ].index.values
 
     first_test_moment = test_data[time_column].min()
     last_test_moment = test_data[time_column].max()
 
-    logs, test_indexes = _get_sc_test_fold_idx_and_logs(test_data, train_time, time_column, first_test_moment,
-                                                        last_test_moment, min_samples, freq)
+    logs, test_indexes = _get_sc_test_fold_idx_and_logs(
+        test_data, train_time, time_column, first_test_moment, last_test_moment, min_samples, freq
+    )
 
     # From "list of dicts" to "dict of lists" hack:
     logs = [{k: [dic[k] for dic in logs] for k in logs[0]}]
@@ -678,14 +727,16 @@ stability_curve_time_space_splitter.__doc__ += splitter_return_docstring
 
 
 @curry
-def forward_stability_curve_time_splitter(train_data: pd.DataFrame,
-                                          training_time_start: DateType,
-                                          training_time_end: DateType,
-                                          time_column: str,
-                                          holdout_gap: timedelta = timedelta(days=0),
-                                          holdout_size: timedelta = timedelta(days=90),
-                                          step: timedelta = timedelta(days=90),
-                                          move_training_start_with_steps: bool = True) -> SplitterReturnType:
+def forward_stability_curve_time_splitter(
+    train_data: pd.DataFrame,
+    training_time_start: DateType,
+    training_time_end: DateType,
+    time_column: str,
+    holdout_gap: timedelta = timedelta(days=0),
+    holdout_size: timedelta = timedelta(days=90),
+    step: timedelta = timedelta(days=90),
+    move_training_start_with_steps: bool = True,
+) -> SplitterReturnType:
     """
     Splits the data into temporal buckets with both the training and testing folds both moving forward.
     The folds move forward by a fixed timedelta step.
@@ -737,33 +788,42 @@ def forward_stability_curve_time_splitter(train_data: pd.DataFrame,
     max_date = train_data[time_column].max()
 
     if not (train_data[time_column].min() <= training_time_start < training_time_end <= max_date):
-        raise ValueError('Temporal training limits should be within datasets temporal bounds (min and max times)')
+        raise ValueError("Temporal training limits should be within datasets temporal bounds (min and max times)")
     if timedelta(days=0) > holdout_gap:
-        raise ValueError('Holdout gap cannot be negative')
+        raise ValueError("Holdout gap cannot be negative")
     if timedelta(days=0) > holdout_size:
-        raise ValueError('Holdout size cannot be negative')
+        raise ValueError("Holdout size cannot be negative")
 
     n_folds = int(np.ceil((max_date - holdout_size - holdout_gap - training_time_end) / step))
 
     if n_folds <= 0:
         raise ValueError(
-            'After taking the gap and holdout into account, there should be enough time for the holdout set')
+            "After taking the gap and holdout into account, there should be enough time for the holdout set"
+        )
 
-    train_ranges = [(training_time_start + i * step * move_training_start_with_steps, training_time_end + i * step)
-                    for i in range(n_folds)]
+    train_ranges = [
+        (training_time_start + i * step * move_training_start_with_steps, training_time_end + i * step)
+        for i in range(n_folds)
+    ]
 
     test_ranges = [
         (training_time_end + holdout_gap + i * step, training_time_end + holdout_gap + holdout_size + i * step)
         for i in range(n_folds)
     ]
 
-    train_idx = [train_data[(train_data[time_column] >= start) & (train_data[time_column] < end)].index
-                 for start, end in train_ranges]
-    test_idx = [[train_data[(train_data[time_column] >= start) & (train_data[time_column] < end)].index]
-                for start, end in test_ranges]
+    train_idx = [
+        train_data[(train_data[time_column] >= start) & (train_data[time_column] < end)].index
+        for start, end in train_ranges
+    ]
+    test_idx = [
+        [train_data[(train_data[time_column] >= start) & (train_data[time_column] < end)].index]
+        for start, end in test_ranges
+    ]
 
-    logs = [_log_time_fold((train_data.iloc[i][time_column], train_data.iloc[j[0]][time_column])) for i, j in
-            zip(train_idx, test_idx)]
+    logs = [
+        _log_time_fold((train_data.iloc[i][time_column], train_data.iloc[j[0]][time_column]))
+        for i, j in zip(train_idx, test_idx)
+    ]
 
     return list(zip(train_idx, test_idx)), logs
 

--- a/src/fklearn/version.py
+++ b/src/fklearn/version.py
@@ -9,7 +9,7 @@ def version() -> str:
     -------
     version : str
     """
-    with open(join(dirname(__file__), 'resources', 'VERSION')) as f:
+    with open(join(dirname(__file__), "resources", "VERSION")) as f:
         return f.read().strip()
 
 


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [X] Documentation: comments on the modified function 
- [X] Tests added and passed: 
                        1. two classes: https://github.com/nubank/cmktai-sas-contxt-senti/blob/dev/evaluators.ipynb, 
                        2. two classes: https://nubank.slack.com/archives/CLXKTQ4JD/p1674852833698369 
                        3. three classes: https://github.com/nubank/grumpy-model/blob/analysis_notebooks/notebooks/development/Comparison_Trainings.ipynb

### Background context
We weren't able to calculate the PR of the "0" class in classification problems, neither apply it to more than two classes' problems. Eg, see: https://github.com/nubank/cmktai-sas-contxt-senti/blob/v0/src/cmktai_sas_contxt_senti/model.py

### Description of the changes proposed in the pull request
1. Included kwargs on the two functions for precision_score and recall_score, allowing to use the parameter "average" and "label_pos" that allows the precision and recall for other classes than the "0" class, since the default value of the parameter average is binary and we couldn't change it.
2. Modified the parameter "threshold" to receive a list of thresholds, so we could classify for more than two classes. Included explicitly also the parameter "labels" that was implicit in kwarg, but which now is used to apply the class for the binned values of prediction according to the list of thresholds.


### Where should the reviewer start?
Changes on the precision_evaluator and recall_evaluator functions on evaluator.py file. All other changes were automatic changes made to comply with lint.

### Remaining problems or questions
There is no remaining questions.

