### PR TITLE
Support new multi-class objectives in lgbm_classification_learner

### DIFF
--- a/src/fklearn/training/classification.py
+++ b/src/fklearn/training/classification.py
@@ -620,9 +620,13 @@ def lgbm_classification_learner(df: pd.DataFrame,
 
     import lightgbm as lgbm
 
+    LGBM_MULTICLASS_OBJECTIVES = {'multiclass', 'softmax', 'multiclassova', 'multiclass_ova', 'ova', 'ovr'}
+
     params = extra_params if extra_params else {}
     params = assoc(params, "eta", learning_rate)
     params = params if "objective" in params else assoc(params, "objective", 'binary')
+
+    is_multiclass_classification = params["objective"] in LGBM_MULTICLASS_OBJECTIVES
 
     weights = df[weight_column].values if weight_column else None
 
@@ -637,7 +641,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
                      callbacks=callbacks)
 
     def p(new_df: pd.DataFrame, apply_shap: bool = False) -> pd.DataFrame:
-        if params["objective"] == "multiclass":
+        if is_multiclass_classification:
             col_dict = {prediction_column + "_" + str(key): value
                         for (key, value) in enumerate(bst.predict(new_df[features].values).T)}
         else:
@@ -649,7 +653,7 @@ def lgbm_classification_learner(df: pd.DataFrame,
             shap_values = explainer.shap_values(new_df[features])
             shap_expected_value = explainer.expected_value
 
-            if params["objective"] == "multiclass":
+            if is_multiclass_classification:
                 shap_values_multiclass = {f"shap_values_{class_index}": list(value)
                                           for (class_index, value) in enumerate(shap_values)}
                 shap_expected_value_multiclass = {


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests passed
- [x] Issue: closes #222 

### Background context
The `lgbm_classification_learner` supported only a `multiclass` objective for a multi-class classification problem.

When a `softmax` (alias for `multiclass`) or a `multiclassova` (and all its aliases) were used as an objective, `lgbm_classification_learner` failed to produce a prediction function, resulting in an error.

### Description of the changes proposed in the pull request
- Added a set `LGBM_MULTICLASS_OBJECTIVES` that contains all multi-class objectives that can be used in LGBM as of today.
- Created a boolean variable `is_multiclass_classification` that determines whether a multi-class problem is being solved or not.
- Replaced two instances of `params["objective"] == "multiclass"` with a single `is_multiclass_classification` boolean variable. This modification directs the flow inside the prediction function `p` to support new multi-class objectives, instead of just `multiclass`.

### Where should the reviewer start?
Changes were only made inside `lgbm_classification_learner`.