### PR TITLE
Update ubuntu image from ubuntu-20.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
@@ -29,7 +29,7 @@ jobs:
             src/ tests/
 
   test-packaging:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
@@ -47,7 +47,7 @@ jobs:
         python3 -m twine check dist/*
 
   test-suite:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", '3.10', "3.11"]
@@ -100,7 +100,7 @@ jobs:
 
   build-docs:
     needs: [linter, test-suite]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9


### PR DESCRIPTION
### Status
**READY**

### Background context
 Publish pipelines are failing because Ubuntu 20.04 LTS runner was removed on 2025-04-15

### Description of the changes proposed in the pull request
Update workflows to use the image ubuntu-24.04

![Screenshot 2025-04-23 at 17 59 04](https://github.com/user-attachments/assets/f55b53d2-16f3-4d27-b6a1-3cb2104d4eb6)


