### PR TITLE
feat(validation): add input validation utilities module

### DIFF
--- a/src/fklearn/exceptions/__init__.py
+++ b/src/fklearn/exceptions/__init__.py
@@ -1,0 +1,19 @@
+from fklearn.exceptions.exceptions import (
+    EmptyDataFrameError,
+    InvalidParameterRangeError,
+    InvalidParameterValueError,
+    MissingColumnsError,
+    MissingControlError,
+    MissingTreatmentError,
+    MultipleTreatmentsError,
+)
+
+__all__ = [
+    "EmptyDataFrameError",
+    "InvalidParameterRangeError",
+    "InvalidParameterValueError",
+    "MissingColumnsError",
+    "MissingControlError",
+    "MissingTreatmentError",
+    "MultipleTreatmentsError",
+]

--- a/src/fklearn/exceptions/exceptions.py
+++ b/src/fklearn/exceptions/exceptions.py
@@ -29,3 +29,81 @@ class MissingTreatmentError(Exception):
         **kwargs: Dict[str, Any]
     ) -> None:
         super().__init__(msg, *args, **kwargs)
+
+
+class MissingColumnsError(Exception):
+    """Raised when required DataFrame columns are missing."""
+
+    def __init__(
+        self,
+        missing_columns: List[str],
+        available_columns: List[str],
+        msg: str = None,
+        *args: List[Any],
+        **kwargs: Dict[str, Any]
+    ) -> None:
+        if msg is None:
+            msg = f"Missing required columns: {missing_columns}. Available: {available_columns}"
+        self.missing_columns = missing_columns
+        self.available_columns = available_columns
+        super().__init__(msg, *args, **kwargs)
+
+
+class EmptyDataFrameError(Exception):
+    """Raised when DataFrame is empty but non-empty is required."""
+
+    def __init__(
+        self,
+        msg: str = "DataFrame is empty but non-empty data is required.",
+        *args: List[Any],
+        **kwargs: Dict[str, Any]
+    ) -> None:
+        super().__init__(msg, *args, **kwargs)
+
+
+class InvalidParameterRangeError(Exception):
+    """Raised when numeric parameter is outside valid range."""
+
+    def __init__(
+        self,
+        param_name: str,
+        value: Any,
+        min_value: Any = None,
+        max_value: Any = None,
+        msg: str = None,
+        *args: List[Any],
+        **kwargs: Dict[str, Any]
+    ) -> None:
+        if msg is None:
+            bounds = []
+            if min_value is not None:
+                bounds.append(f">= {min_value}")
+            if max_value is not None:
+                bounds.append(f"<= {max_value}")
+            bounds_str = " and ".join(bounds) if bounds else "within valid range"
+            msg = f"Parameter '{param_name}' has value {value}, but must be {bounds_str}."
+        self.param_name = param_name
+        self.value = value
+        self.min_value = min_value
+        self.max_value = max_value
+        super().__init__(msg, *args, **kwargs)
+
+
+class InvalidParameterValueError(Exception):
+    """Raised when parameter value is not in allowed set."""
+
+    def __init__(
+        self,
+        param_name: str,
+        value: Any,
+        allowed_values: List[Any],
+        msg: str = None,
+        *args: List[Any],
+        **kwargs: Dict[str, Any]
+    ) -> None:
+        if msg is None:
+            msg = f"Parameter '{param_name}' has value '{value}', but must be one of: {allowed_values}."
+        self.param_name = param_name
+        self.value = value
+        self.allowed_values = allowed_values
+        super().__init__(msg, *args, **kwargs)

--- a/src/fklearn/training/imputation.py
+++ b/src/fklearn/training/imputation.py
@@ -7,6 +7,13 @@ from toolz import curry, identity
 from fklearn.common_docstrings import learner_return_docstring, learner_pred_fn_docstring
 from fklearn.types import LearnerReturnType
 from fklearn.training.utils import log_learner_time
+from fklearn.validation import (
+    validate_columns_exist,
+    validate_nonempty_df,
+    validate_value_in_set,
+)
+
+VALID_IMPUTE_STRATEGIES = ['mean', 'median', 'most_frequent']
 
 
 @curry
@@ -39,6 +46,10 @@ def imputer(df: pd.DataFrame,
         NA values on training. For transformation, NA values on those features
         will be replaced by `fill_value`.
     """
+    # Input validation
+    validate_nonempty_df(df, context='imputer')
+    validate_columns_exist(df, columns_to_impute, context='imputer')
+    validate_value_in_set(impute_strategy, 'impute_strategy', VALID_IMPUTE_STRATEGIES)
 
     if placeholder_value is not None:
         mask_feat_is_na = df[columns_to_impute].isna().all(axis=0)

--- a/src/fklearn/validation/__init__.py
+++ b/src/fklearn/validation/__init__.py
@@ -1,0 +1,15 @@
+from fklearn.validation.input_validators import (
+    validate_columns_exist,
+    validate_nonempty_df,
+    validate_positive_int,
+    validate_range,
+    validate_value_in_set,
+)
+
+__all__ = [
+    "validate_columns_exist",
+    "validate_nonempty_df",
+    "validate_positive_int",
+    "validate_range",
+    "validate_value_in_set",
+]

--- a/src/fklearn/validation/input_validators.py
+++ b/src/fklearn/validation/input_validators.py
@@ -1,0 +1,214 @@
+"""
+Input validation utilities for fklearn.
+
+This module provides curried validation functions following the fklearn functional
+style with @curry decorators and composable design.
+"""
+from typing import Any, List, Optional, Set, Union
+
+import pandas as pd
+from toolz import curry
+
+from fklearn.exceptions import (
+    EmptyDataFrameError,
+    InvalidParameterRangeError,
+    InvalidParameterValueError,
+    MissingColumnsError,
+)
+
+
+@curry
+def validate_columns_exist(
+    df: pd.DataFrame,
+    columns: List[str],
+    context: Optional[str] = None
+) -> None:
+    """
+    Validate that all specified columns exist in the DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to validate.
+    columns : List[str]
+        List of column names that must exist in the DataFrame.
+    context : Optional[str]
+        Optional context string for error messages (e.g., function name).
+
+    Raises
+    ------
+    MissingColumnsError
+        If any of the specified columns are not present in the DataFrame.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    >>> validate_columns_exist(df, ['a', 'b'])  # No error
+    >>> validate_columns_exist(df, ['a', 'c'])  # Raises MissingColumnsError
+    """
+    available_columns = set(df.columns)
+    required_columns = set(columns)
+    missing = required_columns - available_columns
+
+    if missing:
+        context_prefix = f"[{context}] " if context else ""
+        msg = (
+            f"{context_prefix}Missing required columns: {sorted(missing)}. "
+            f"Available: {sorted(available_columns)}"
+        )
+        raise MissingColumnsError(
+            missing_columns=sorted(missing),
+            available_columns=sorted(available_columns),
+            msg=msg
+        )
+
+
+@curry
+def validate_nonempty_df(
+    df: pd.DataFrame,
+    context: Optional[str] = None
+) -> None:
+    """
+    Validate that the DataFrame is not empty.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to validate.
+    context : Optional[str]
+        Optional context string for error messages (e.g., function name).
+
+    Raises
+    ------
+    EmptyDataFrameError
+        If the DataFrame has no rows.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({'a': [1, 2]})
+    >>> validate_nonempty_df(df)  # No error
+    >>> validate_nonempty_df(pd.DataFrame())  # Raises EmptyDataFrameError
+    """
+    if len(df) == 0:
+        context_prefix = f"[{context}] " if context else ""
+        msg = f"{context_prefix}DataFrame is empty but non-empty data is required."
+        raise EmptyDataFrameError(msg=msg)
+
+
+@curry
+def validate_range(
+    value: Union[int, float],
+    param_name: str,
+    min_value: Optional[Union[int, float]] = None,
+    max_value: Optional[Union[int, float]] = None
+) -> None:
+    """
+    Validate that a numeric value is within the specified range.
+
+    Parameters
+    ----------
+    value : Union[int, float]
+        The value to validate.
+    param_name : str
+        Name of the parameter (for error messages).
+    min_value : Optional[Union[int, float]]
+        Minimum allowed value (inclusive). None means no lower bound.
+    max_value : Optional[Union[int, float]]
+        Maximum allowed value (inclusive). None means no upper bound.
+
+    Raises
+    ------
+    InvalidParameterRangeError
+        If the value is outside the specified range.
+
+    Examples
+    --------
+    >>> validate_range(5, 'n_estimators', min_value=1, max_value=100)  # No error
+    >>> validate_range(0, 'n_estimators', min_value=1)  # Raises InvalidParameterRangeError
+    """
+    if min_value is not None and value < min_value:
+        raise InvalidParameterRangeError(
+            param_name=param_name,
+            value=value,
+            min_value=min_value,
+            max_value=max_value
+        )
+    if max_value is not None and value > max_value:
+        raise InvalidParameterRangeError(
+            param_name=param_name,
+            value=value,
+            min_value=min_value,
+            max_value=max_value
+        )
+
+
+@curry
+def validate_value_in_set(
+    value: Any,
+    param_name: str,
+    allowed_values: Union[List[Any], Set[Any]]
+) -> None:
+    """
+    Validate that a value is in the set of allowed values.
+
+    Parameters
+    ----------
+    value : Any
+        The value to validate.
+    param_name : str
+        Name of the parameter (for error messages).
+    allowed_values : Union[List[Any], Set[Any]]
+        Collection of allowed values.
+
+    Raises
+    ------
+    InvalidParameterValueError
+        If the value is not in the allowed set.
+
+    Examples
+    --------
+    >>> validate_value_in_set('mean', 'strategy', ['mean', 'median'])  # No error
+    >>> validate_value_in_set('mode', 'strategy', ['mean', 'median'])  # Raises InvalidParameterValueError
+    """
+    if value not in allowed_values:
+        raise InvalidParameterValueError(
+            param_name=param_name,
+            value=value,
+            allowed_values=list(allowed_values)
+        )
+
+
+@curry
+def validate_positive_int(
+    value: int,
+    param_name: str
+) -> None:
+    """
+    Validate that a value is a positive integer (>= 1).
+
+    Parameters
+    ----------
+    value : int
+        The value to validate.
+    param_name : str
+        Name of the parameter (for error messages).
+
+    Raises
+    ------
+    InvalidParameterRangeError
+        If the value is not a positive integer.
+
+    Examples
+    --------
+    >>> validate_positive_int(5, 'n_folds')  # No error
+    >>> validate_positive_int(0, 'n_folds')  # Raises InvalidParameterRangeError
+    """
+    if not isinstance(value, int) or value < 1:
+        raise InvalidParameterRangeError(
+            param_name=param_name,
+            value=value,
+            min_value=1,
+            msg=f"Parameter '{param_name}' must be a positive integer (>= 1), got {value}."
+        )

--- a/tests/validation/test_input_validators.py
+++ b/tests/validation/test_input_validators.py
@@ -1,0 +1,168 @@
+import pandas as pd
+import pytest
+
+from fklearn.exceptions import (
+    EmptyDataFrameError,
+    InvalidParameterRangeError,
+    InvalidParameterValueError,
+    MissingColumnsError,
+)
+from fklearn.validation import (
+    validate_columns_exist,
+    validate_nonempty_df,
+    validate_positive_int,
+    validate_range,
+    validate_value_in_set,
+)
+
+
+class TestValidateColumnsExist:
+    def test_valid_columns_no_error(self):
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
+        # Should not raise
+        validate_columns_exist(df, ['a', 'b'])
+
+    def test_missing_columns_raises_error(self):
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+        with pytest.raises(MissingColumnsError) as exc_info:
+            validate_columns_exist(df, ['a', 'c', 'd'])
+
+        assert exc_info.value.missing_columns == ['c', 'd']
+        assert set(exc_info.value.available_columns) == {'a', 'b'}
+
+    def test_context_in_error_message(self):
+        df = pd.DataFrame({'a': [1, 2]})
+        with pytest.raises(MissingColumnsError) as exc_info:
+            validate_columns_exist(df, ['b'], context='my_function')
+
+        assert '[my_function]' in str(exc_info.value)
+
+    def test_empty_columns_list_no_error(self):
+        df = pd.DataFrame({'a': [1, 2]})
+        # Should not raise for empty column list
+        validate_columns_exist(df, [])
+
+    def test_curried_usage(self):
+        df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+        validator = validate_columns_exist(columns=['a', 'b'])
+        # Should not raise
+        validator(df)
+
+
+class TestValidateNonemptyDf:
+    def test_nonempty_df_no_error(self):
+        df = pd.DataFrame({'a': [1, 2]})
+        # Should not raise
+        validate_nonempty_df(df)
+
+    def test_empty_df_raises_error(self):
+        df = pd.DataFrame()
+        with pytest.raises(EmptyDataFrameError):
+            validate_nonempty_df(df)
+
+    def test_empty_df_with_columns_raises_error(self):
+        df = pd.DataFrame({'a': [], 'b': []})
+        with pytest.raises(EmptyDataFrameError):
+            validate_nonempty_df(df)
+
+    def test_context_in_error_message(self):
+        df = pd.DataFrame()
+        with pytest.raises(EmptyDataFrameError) as exc_info:
+            validate_nonempty_df(df, context='imputer')
+
+        assert '[imputer]' in str(exc_info.value)
+
+    def test_curried_usage(self):
+        validator = validate_nonempty_df(context='test')
+        df = pd.DataFrame({'a': [1]})
+        # Should not raise
+        validator(df)
+
+
+class TestValidateRange:
+    def test_value_in_range_no_error(self):
+        validate_range(5, 'param', min_value=1, max_value=10)
+
+    def test_value_at_min_boundary_no_error(self):
+        validate_range(1, 'param', min_value=1, max_value=10)
+
+    def test_value_at_max_boundary_no_error(self):
+        validate_range(10, 'param', min_value=1, max_value=10)
+
+    def test_value_below_min_raises_error(self):
+        with pytest.raises(InvalidParameterRangeError) as exc_info:
+            validate_range(0, 'n_estimators', min_value=1, max_value=100)
+
+        assert exc_info.value.param_name == 'n_estimators'
+        assert exc_info.value.value == 0
+        assert exc_info.value.min_value == 1
+
+    def test_value_above_max_raises_error(self):
+        with pytest.raises(InvalidParameterRangeError) as exc_info:
+            validate_range(101, 'n_estimators', min_value=1, max_value=100)
+
+        assert exc_info.value.param_name == 'n_estimators'
+        assert exc_info.value.value == 101
+        assert exc_info.value.max_value == 100
+
+    def test_only_min_bound(self):
+        validate_range(100, 'param', min_value=1)  # No error
+        with pytest.raises(InvalidParameterRangeError):
+            validate_range(0, 'param', min_value=1)
+
+    def test_only_max_bound(self):
+        validate_range(-100, 'param', max_value=10)  # No error
+        with pytest.raises(InvalidParameterRangeError):
+            validate_range(11, 'param', max_value=10)
+
+    def test_curried_usage(self):
+        validator = validate_range(param_name='learning_rate', min_value=0.0, max_value=1.0)
+        validator(0.5)  # Should not raise
+        with pytest.raises(InvalidParameterRangeError):
+            validator(1.5)
+
+
+class TestValidateValueInSet:
+    def test_valid_value_no_error(self):
+        validate_value_in_set('mean', 'strategy', ['mean', 'median', 'mode'])
+
+    def test_invalid_value_raises_error(self):
+        with pytest.raises(InvalidParameterValueError) as exc_info:
+            validate_value_in_set('average', 'strategy', ['mean', 'median', 'mode'])
+
+        assert exc_info.value.param_name == 'strategy'
+        assert exc_info.value.value == 'average'
+        assert 'mean' in exc_info.value.allowed_values
+
+    def test_works_with_set(self):
+        validate_value_in_set('a', 'param', {'a', 'b', 'c'})  # No error
+        with pytest.raises(InvalidParameterValueError):
+            validate_value_in_set('d', 'param', {'a', 'b', 'c'})
+
+    def test_curried_usage(self):
+        validator = validate_value_in_set(param_name='impute_strategy', allowed_values=['mean', 'median'])
+        validator('mean')  # Should not raise
+        with pytest.raises(InvalidParameterValueError):
+            validator('mode')
+
+
+class TestValidatePositiveInt:
+    def test_positive_int_no_error(self):
+        validate_positive_int(1, 'n_folds')
+        validate_positive_int(100, 'n_folds')
+
+    def test_zero_raises_error(self):
+        with pytest.raises(InvalidParameterRangeError) as exc_info:
+            validate_positive_int(0, 'n_folds')
+
+        assert exc_info.value.param_name == 'n_folds'
+
+    def test_negative_raises_error(self):
+        with pytest.raises(InvalidParameterRangeError):
+            validate_positive_int(-1, 'n_folds')
+
+    def test_curried_usage(self):
+        validator = validate_positive_int(param_name='batch_size')
+        validator(32)  # Should not raise
+        with pytest.raises(InvalidParameterRangeError):
+            validator(0)


### PR DESCRIPTION
## Summary

- Add curried validation functions for DataFrame operations following fklearn's functional style
- Add custom exceptions for better error messages
- Integrate validation into `imputer()` as demonstration

### New Validators (`fklearn.validation`)
- `validate_columns_exist`: check required columns exist in DataFrame
- `validate_nonempty_df`: ensure DataFrame is not empty
- `validate_range`: numeric parameter bounds validation
- `validate_value_in_set`: allowed values check
- `validate_positive_int`: positive integer validation

### New Exceptions (`fklearn.exceptions`)
- `MissingColumnsError`
- `EmptyDataFrameError`
- `InvalidParameterRangeError`
- `InvalidParameterValueError`

## Motivation

The codebase currently has only 27 error-raising statements in ~9,150 lines of code. This module improves error handling by catching issues early with descriptive error messages.

## Test plan

- [x] Added unit tests in `tests/validation/test_input_validators.py`
- [ ] Run `pytest tests/validation/test_input_validators.py -v`
- [ ] Run `pytest tests/training/test_imputation.py -v`