### PR TITLE
Add support for validation sets and callbacks on lgbm learner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 joblib>=1.3.2,<2
+# AttributeError: module 'coverage' has no attribute 'types'
+# numba<0.64.0
+numba==0.65.0
 numpy>=1.24.4,<2
 pandas>=2,<3
 scikit-learn>=1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 joblib>=1.3.2,<2
-# AttributeError: module 'coverage' has no attribute 'types'
-# numba<0.64.0
-numba==0.65.0
 numpy>=1.24.4,<2
 pandas>=2,<3
 scikit-learn>=1,<2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,6 @@ pytest>=7.4.3,<8
 pytest-cov>=2.6.1,<3
 pytest-xdist>=3.3.1,<4
 mypy>=1.6.1,<2
-coverage<5
+coverage<8
 codecov>=2.0,<3
 hypothesis>=6.88.3,<7

--- a/src/fklearn/training/regression.py
+++ b/src/fklearn/training/regression.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, List, Union
+from typing import Any, Callable, Dict, Optional, List, Union
 
 import numpy as np
 import pandas as pd

--- a/src/fklearn/training/regression.py
+++ b/src/fklearn/training/regression.py
@@ -459,7 +459,7 @@ def lgbm_regression_learner(
 
     target : str
         The name of the column in `df` that should be used as target for the model.
-        This column should be binary, since this is a classification model.
+        This column should be binary, if the objective is classification.
 
     learning_rate : float
         Float in the range (0, 1]
@@ -489,6 +489,13 @@ def lgbm_regression_learner(
 
     encode_extra_cols : bool (default: True)
         If True, treats all columns in `df` with name pattern fklearn_feat__col==val` as feature columns.
+
+    valid_dfs : list of pandas.DataFrame, optional (default=None)
+        A list of datasets to be used for early-stopping during training.
+
+    callbacks : list of callable, or None, optional (default=None)
+        List of callback functions that are applied at each iteration.
+        See Callbacks in LightGBM Python API for more information.
     """
 
     import lightgbm as lgbm

--- a/src/fklearn/training/regression.py
+++ b/src/fklearn/training/regression.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Any, Callable, Optional, List, Union
 
 import numpy as np
 import pandas as pd
@@ -434,7 +434,9 @@ def lgbm_regression_learner(
         extra_params: Dict[str, Any] = None,
         prediction_column: str = "prediction",
         weight_column: str = None,
-        encode_extra_cols: bool = True
+        encode_extra_cols: bool = True,
+        valid_dfs: Optional[List[pd.DataFrame]] = None,
+        callbacks: Optional[List[Callable]] = None,
 ) -> LearnerReturnType:
     """
     Fits an LGBM regressor to the dataset.
@@ -500,8 +502,16 @@ def lgbm_regression_learner(
     features = features if not encode_extra_cols else expand_features_encoded(df, features)
 
     dtrain = lgbm.Dataset(df[features].values, label=df[target], feature_name=list(map(str, features)), weight=weights)
+    valid_sets = [
+        lgbm.Dataset(
+            valid_df[features].values,
+            label=valid_df[target],
+            feature_name=list(map(str, features)),
+            weight=valid_df[weight_column].values if weight_column else None)
+        for valid_df in valid_dfs
+    ] if valid_dfs else [dtrain]
 
-    bst = lgbm.train(params, dtrain, num_estimators)
+    bst = lgbm.train(params, dtrain, num_estimators, valid_sets=valid_sets, callbacks=callbacks)
 
     def p(new_df: pd.DataFrame, apply_shap: bool = False) -> pd.DataFrame:
         col_dict = {prediction_column: bst.predict(new_df[features].values)}

--- a/tests/training/test_regression.py
+++ b/tests/training/test_regression.py
@@ -1,5 +1,6 @@
 from collections import Counter
 
+import lightgbm
 import numpy as np
 import pandas as pd
 
@@ -193,9 +194,11 @@ def test_lgbm_regression_learner():
                                       num_estimators=20,
                                       extra_params={"max_depth": 2, "seed": 42},
                                       prediction_column="prediction",
-                                      weight_column="w")
+                                      weight_column="w",
+                                      callbacks=[lightgbm.log_evaluation()]
+                                      )
 
-    predict_fn, pred_train, log = learner(df_train)
+    predict_fn, pred_train, log = learner(df_train, valid_dfs=[df_train])
 
     pred_test = predict_fn(df_test)
 


### PR DESCRIPTION
### Status
**READY**

### Todo list
- [x] Documentation
- [x] Tests added and passed

### Background context
The `lgbm_regression_learner` did not support validation sets or callbacks, limiting the ability to use early stopping and monitor training progress — features already available in the classification counterpart (`lgbm_classification_learner`).

### Description of the changes proposed in the pull request
- Add `valid_dfs` and `callbacks` parameters to `lgbm_regression_learner`, matching the interface of `lgbm_classification_learner`
- When `valid_dfs` is provided, create LightGBM validation datasets (with proper feature names and weights) for early-stopping support
- Pass `callbacks` through to `lgbm.train` for iteration-level hooks (e.g. `lgbm.early_stopping`, `lgbm.log_evaluation`)
- Update docstring to document the new parameters and fix an incorrect description of the `target` column
- Bumped `coverage` so it's compatible with newer versions of `numba`

### Where should the reviewer start?
`src/fklearn/training/regression.py` — the changes to `lgbm_regression_learner`