### PR TITLE
bump rc 4.2 as official release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.2.0rc0] - unreleased
+## [4.2.0] - 2026-04-22
 - **Enhancement**
   - Support `numpy>=1.26,<3` (adds numpy 2.x support).
   - Bump `scikit-learn` range to `>=1.5,<1.8` (numpy 2.x support starts in 1.5; this

--- a/README.md
+++ b/README.md
@@ -44,10 +44,20 @@ pip install fklearn[all]        # All models + tools
 
 ## Development with UV
 
+fklearn uses [uv](https://docs.astral.sh/uv/) for dependency management. `uv sync`
+creates a virtual environment, installs all locked dependencies, and installs
+fklearn itself in **editable mode** (the default for uv projects) so changes
+under `src/` are picked up without reinstalling.
+
 ### Setup
 ```bash
-uv sync --extra devel
+uv sync                 # core deps + dev group
+uv sync --all-extras    # also installs lgbm / xgboost / catboost / tools / demos / docs
 ```
+
+The `dev` dependency group (pytest, ruff, mypy, hypothesis) is included by
+default via `tool.uv.default-groups`, so `uv sync` alone is enough for most
+development workflows.
 
 ### Running Tests
 ```bash
@@ -64,6 +74,14 @@ uv run ruff format src/ tests/
 ```bash
 uv add <package-name>          # runtime dependency
 uv add --dev <package-name>    # dev dependency
+```
+
+### Note for Nubank contributors
+
+Regenerate the lockfile with `--default-index https://pypi.org/simple/`:
+
+```bash
+uv lock --default-index https://pypi.org/simple/
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fklearn"
-version = "4.2.0rc0"
+version = "4.2.0"
 description = "Functional machine learning"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "fklearn"
-version = "4.2.0rc0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },


### PR DESCRIPTION
- Promote `4.2.0rc0` to the official **4.2.0** release.
- Rename the CHANGELOG entry to `[4.2.0] - 2026-04-22` (no content changes: numpy 2.x, scikit-learn bump, SHAP/lightgbm fixes, stable-sort fix in causal curves).
- Clean up the README dev section (correct `uv sync` invocation, mention editable install, note for Nubank contributors to use `--default-index https://pypi.org/simple/` when regenerating `uv.lock`).
