### PR TITLE
Fix typos in user-facing docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.2.3] - 2026-05-11
+- **Documentation**
+  - Fix typos in user-facing docstrings: `capper` (`os` → `of`, `caped` → `capped`), `floorer` (`os` → `of`, `floot` → `floor`, `minimun` → `minimum`), `stop_by_num_features` / `stop_by_num_features_parallel` (`minimun` → `minimum`).
+
 ## [4.2.2] - 2026-04-24
 - **Internal**
   - CI: add `validate-bump` job to the `push` workflow, backed by `scripts/validate_bump.sh`, so PRs that modify `src/`, `pyproject.toml` or `uv.lock` must bump the version (and, for non-patch bumps, update the CHANGELOG). `get_default_branch` falls back through `git symbolic-ref` → `$GITHUB_BASE_REF` → `git remote show origin`, so the script works locally (where `git clone` sets `origin/HEAD`) and in GitHub Actions (where `actions/checkout@v6` does not).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fklearn"
-version = "4.2.2"
+version = "4.2.3"
 description = "Functional machine learning"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/fklearn/training/transformation.py
+++ b/src/fklearn/training/transformation.py
@@ -69,7 +69,7 @@ def capper(df: pd.DataFrame, columns_to_cap: List[str], precomputed_caps: Dict[s
         A Pandas' DataFrame that must contain `columns_to_cap` columns.
 
     columns_to_cap : list of str
-        A list os column names that should be caped.
+        A list of column names that should be capped.
 
     precomputed_caps : dict
         A dictionary on the format {"column_name" : cap_value}.
@@ -103,9 +103,9 @@ def floorer(
 ) -> LearnerReturnType:
     """
     Learns the minimum value for each of the `columns_to_floor`
-    and used that as the floot for those columns. If precomputed floors
+    and used that as the floor for those columns. If precomputed floors
     are passed, the function uses that as the cap value instead of
-    computing the minimun.
+    computing the minimum.
 
     Parameters
     ----------
@@ -114,7 +114,7 @@ def floorer(
         A Pandas' DataFrame that must contain `columns_to_floor` columns.
 
     columns_to_floor : list of str
-        A list os column names that should be floored.
+        A list of column names that should be floored.
 
     precomputed_floors : dict
         A dictionary on the format {"column_name" : floor_value}

--- a/src/fklearn/tuning/stoppers.py
+++ b/src/fklearn/tuning/stoppers.py
@@ -153,7 +153,7 @@ def stop_by_num_features(logs: ListLogListType, min_num_features: int = 50) -> b
         A list of log-like lists of dictionaries evaluations.
 
     min_num_features: int (default 50)
-        The minimun number of features the model can have before stopping
+        The minimum number of features the model can have before stopping
 
     Returns
     -------
@@ -183,7 +183,7 @@ def stop_by_num_features_parallel(
         String with the name of the column that refers to the metric column to be extracted
 
     min_num_features: int (default 50)
-        The minimun number of features the model can have before stopping
+        The minimum number of features the model can have before stopping
 
     Returns
     ----------

--- a/uv.lock
+++ b/uv.lock
@@ -583,7 +583,7 @@ wheels = [
 
 [[package]]
 name = "fklearn"
-version = "4.2.2"
+version = "4.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },


### PR DESCRIPTION
## Summary
- Fix six misspellings in docstrings that ship to readthedocs:
  - `capper` / `floorer` in `src/fklearn/training/transformation.py`: `os` → `of`, `caped` → `capped`, `floot` → `floor`, `minimun` → `minimum`.
  - `stop_by_num_features` and `stop_by_num_features_parallel` in `src/fklearn/tuning/stoppers.py`: `minimun` → `minimum`.
- Bump version to `4.2.3` (required by `scripts/validate_bump.sh` because `src/` changed) and add a matching CHANGELOG entry.

No code behavior changes.

## Test plan
- [x] `bash scripts/validate_bump.sh` passes locally
- [x] CI: linter, formatter-check, mypy, test-suite (3.10–3.13), build-docs all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)